### PR TITLE
Checking array range in linebuffer and basicops

### DIFF
--- a/backtrader/indicators/basicops.py
+++ b/backtrader/indicators/basicops.py
@@ -262,7 +262,10 @@ class Average(PeriodN):
         dst = self.line.array
         period = self.p.period
 
-        for i in range(start, end):
+        # array limit safety check
+        realend = min(end, len(dst))
+
+        for i in range(start, realend):
             dst[i] = math.fsum(src[i - period + 1:i + 1]) / period
 
 
@@ -305,7 +308,7 @@ class ExponentialSmoothing(Average):
         alpha1 = self.alpha1
 
         # Seed value from SMA calculated with the call to oncestart
-        prev = larray[start - 1]
+        prev = larray[start - 1] if start <= len(larray) else float('NaN')
         for i in range(start, end):
             larray[i] = prev = prev * alpha1 + darray[i] * alpha
 

--- a/backtrader/linebuffer.py
+++ b/backtrader/linebuffer.py
@@ -766,7 +766,7 @@ class LinesOperation(LineActions):
         # array range safety check
         realend = min(len(srca), len(dst), end)
 
-        for i in range(start, end):
+        for i in range(start, realend):
             dst[i] = op(srca[i], srcb)
 
     def _once_val_op_r(self, start, end):

--- a/backtrader/linebuffer.py
+++ b/backtrader/linebuffer.py
@@ -779,7 +779,7 @@ class LinesOperation(LineActions):
         # array range safety check
         realend = min(len(srcb), len(dst), end)
 
-        for i in range(start, end):
+        for i in range(start, realend):
             dst[i] = op(srca, srcb[i])
 
 

--- a/backtrader/linebuffer.py
+++ b/backtrader/linebuffer.py
@@ -656,7 +656,11 @@ class _LineDelay(LineActions):
         src = self.a.array
         ago = self.ago
 
-        for i in range(start, end):
+        # array range safety check
+        realend = min(end, len(dst))
+        realend = realend if len(src) > (realend + ago) else len(src)
+
+        for i in range(start, realend):
             dst[i] = src[i + ago]
 
 
@@ -746,7 +750,10 @@ class LinesOperation(LineActions):
         srcb = self.b.array
         op = self.operation
 
-        for i in range(start, end):
+        # array range safety check
+        realend = min(len(srca), len(srcb), len(dst), end)
+
+        for i in range(start, realend):
             dst[i] = op(srca[i], srcb[i])
 
     def _once_val_op(self, start, end):
@@ -755,6 +762,9 @@ class LinesOperation(LineActions):
         srca = self.a.array
         srcb = self.b
         op = self.operation
+
+        # array range safety check
+        realend = min(len(srca), len(dst), end)
 
         for i in range(start, end):
             dst[i] = op(srca[i], srcb)
@@ -765,6 +775,9 @@ class LinesOperation(LineActions):
         srca = self.a
         srcb = self.b.array
         op = self.operation
+
+        # array range safety check
+        realend = min(len(srcb), len(dst), end)
 
         for i in range(start, end):
             dst[i] = op(srca, srcb[i])


### PR DESCRIPTION
`IndexError` happens in a few places if data length is less than certain indicators expect it to be. Not sure if this is the best way to handle it though, but it does the job.