### PR TITLE
annualize the sharpe ratio

### DIFF
--- a/backtrader/analyzers/sharpe.py
+++ b/backtrader/analyzers/sharpe.py
@@ -125,6 +125,6 @@ class SharpeRatio(Analyzer):
             ret_free = map(operator.sub, returns, retfree)
             ret_free_avg = average(list(ret_free))
             retdev = standarddev(returns)
-
-            self.ratio = ret_free_avg / retdev
+            
+            self.ratio = (ret_free_avg / retdev) * (factor ** .5)
             self.rets['sharperatio'] = self.ratio


### PR DESCRIPTION
I have always seen the Sharpe ratio given in an annualized form rather than a raw form. If I am using daily returns and my risk free return is annual, I want to know how much in excess of the risk free return I am generating. Hence, multiplying the average excess return by 365 and the standard deviation by sqrt(365) gets the above calculation.