### PR TITLE
Reverted to original patch, since it fixes the floating point representation error...

### DIFF
--- a/backtrader/indicators/deviation.py
+++ b/backtrader/indicators/deviation.py
@@ -31,14 +31,11 @@ class StandardDeviation(Indicator):
     Note:
       - If 2 datas are provided as parameters, the 2nd is considered to be the
         mean of the first
-      - ``safepow´´ (default: False) If this parameter is True, the standard deviation
-        will be calculated as pow(abs(meansq - sqmean), 0.5) to safe guard for possible
-        negative results of ``meansq - sqmean´´ caused by the floating point representation.
 
     Formula:
       - meansquared = SimpleMovingAverage(pow(data, 2), period)
       - squaredmean = pow(SimpleMovingAverage(data, period), 2)
-      - stddev = pow(meansquared - squaredmean, 0.5)  # square root
+      - stddev = pow(abs(meansquared - squaredmean), 0.5)  # square root
 
     See:
       - http://en.wikipedia.org/wiki/Standard_deviation
@@ -46,7 +43,7 @@ class StandardDeviation(Indicator):
     alias = ('StdDev',)
 
     lines = ('stddev',)
-    params = (('period', 20), ('movav', MovAv.Simple), ('safepow', False),)
+    params = (('period', 20), ('movav', MovAv.Simple),)
 
     def _plotlabel(self):
         plabels = [self.p.period]
@@ -62,10 +59,7 @@ class StandardDeviation(Indicator):
         meansq = self.p.movav(pow(self.data, 2), period=self.p.period)
         sqmean = pow(mean, 2)
 
-        if self.p.safepow:
-            self.lines.stddev = pow(abs(meansq - sqmean), 0.5)
-        else:
-            self.lines.stddev = pow(meansq - sqmean, 0.5)
+        self.lines.stddev = pow(abs(meansq - sqmean), 0.5)
 
 
 class MeanDeviation(Indicator):


### PR DESCRIPTION
... also when StdDev() is called indirectly, e.g. via the BollingerBands indicator.

The problem with introducing the `safepow` parameter is, that when `StdDev()` is used indirectly, there is no option to set `safepow=True`. This leaves us with the original behaviour and it's only a matter of time before the execution breaks.

I propose the original patch again, for several reasons.

- Code not breaking today will continue to work as using `abs()` on positive numbers will not alter the number.
- No extra parameter to keep track of, i.e. cleaner code/design.
- `StdDev()` will always work, also when used indirectly.

Alternative solutions would be to 

1. _Set the default value of `safepow´ to `True`_, but that would leave us with an extra check of a parameter, which with high probability will never be set to `False`, since who would want the code to break, when the risk is known.

2. _Update the classes where `StdDev()` is called_, by adding a parameter similar to `safepow`. I could only find the Bollinger Bands indicator, so the work would not be huge, but its kind of bad design.

3. _Use an environment variable_, which feels like making too big of a problem out of this issue.

_Note_: I would actually be happy also with solution 1 above, but removing the check altogether feels like the better solution, since the floating point representation is as it is and the code would break eventually by leaving out the `abs()`.

Please let me know what you think. Thanks!