### PR TITLE
Avoid raising exception in analyzers.SQN if no trade has been made

### DIFF
--- a/backtrader/analyzers/sharpe.py
+++ b/backtrader/analyzers/sharpe.py
@@ -136,7 +136,7 @@ class SharpeRatio(Analyzer):
             retavg = average([r - rate for r in self.anret.rets])
             retdev = standarddev(self.anret.rets)
 
-            self.ratio = retavg / retdev if retdev else math.nan
+            self.ratio = retavg / retdev if retdev else None
         else:
             # Get the returns from the subanalyzer
             returns = list(itervalues(self.timereturn.get_analysis()))

--- a/backtrader/analyzers/sharpe.py
+++ b/backtrader/analyzers/sharpe.py
@@ -136,7 +136,7 @@ class SharpeRatio(Analyzer):
             retavg = average([r - rate for r in self.anret.rets])
             retdev = standarddev(self.anret.rets)
 
-            self.ratio = retavg / retdev
+            self.ratio = retavg / retdev if retdev else math.nan
         else:
             # Get the returns from the subanalyzer
             returns = list(itervalues(self.timereturn.get_analysis()))
@@ -174,9 +174,9 @@ class SharpeRatio(Analyzer):
             retdev = standarddev(ret_free, avgx=ret_free_avg,
                                  bessel=self.p.stddev_sample)
 
-            ratio = ret_free_avg / retdev
+            ratio = ret_free_avg / retdev if retdev else None
 
-            if factor is not None and self.p.convertrate and self.p.annualize:
+            if ratio and factor is not None and self.p.convertrate and self.p.annualize:
                 ratio = math.sqrt(factor) * ratio
 
             self.ratio = ratio
@@ -197,3 +197,4 @@ class SharpeRatio_A(SharpeRatio):
     params = (
         ('annualize', True),
     )
+

--- a/backtrader/analyzers/sqn.py
+++ b/backtrader/analyzers/sqn.py
@@ -72,7 +72,7 @@ class SQN(Analyzer):
 
     def stop(self):
         if self.count == 0:
-            self.rets.sqn = math.nan
+            self.rets.sqn = None
             self.rets.trades = 0
             return
 

--- a/backtrader/analyzers/sqn.py
+++ b/backtrader/analyzers/sqn.py
@@ -71,6 +71,11 @@ class SQN(Analyzer):
             self.count += 1
 
     def stop(self):
+        if self.count == 0:
+            self.rets.sqn = math.nan
+            self.rets.trades = 0
+            return
+
         pnl_av = average(self.pnl)
         pnl_stddev = standarddev(self.pnl)
 


### PR DESCRIPTION
This simple example script raises `ZeroDivisionError: float division by zero`:

```python
import datetime

import backtrader as bt
import pandas as pd

if __name__ == '__main__':
    c = bt.Cerebro()
    df = pd.read_csv('datas/orcl-1995-2014.txt', parse_dates=['Date'], index_col='Date')
    c.adddata(bt.feeds.PandasData(dataname=df))
    c.addanalyzer(bt.analyzers.SQN)
    c.run()
```

It is pretty annoying as the SQN analyzer keeps tripping in various places.

The design decision to use `None` instead of `0` for SQN in this case is that not having made any trade should not be indicative of the quality of the system. I.e. the system is not "very poor" if it doesn't feel like trading for a period of time because it is not very confident.