### PR TITLE
Delegate put_notifications in Chainer

### DIFF
--- a/backtrader/feeds/chainer.py
+++ b/backtrader/feeds/chainer.py
@@ -74,7 +74,7 @@ class Chainer(bt.with_metaclass(MetaChainer, bt.DataBase)):
             d.stop()
 
     def get_notifications(self):
-        return self._d.get_notifications()
+        return [] if self._d is None else self._d.get_notifications()
 
     def _gettz(self):
         '''To be overriden by subclasses which may auto-calculate the

--- a/backtrader/feeds/chainer.py
+++ b/backtrader/feeds/chainer.py
@@ -73,6 +73,9 @@ class Chainer(bt.with_metaclass(MetaChainer, bt.DataBase)):
         for d in self._args:
             d.stop()
 
+    def get_notifications(self):
+        return self._d.get_notifications()
+
     def _gettz(self):
         '''To be overriden by subclasses which may auto-calculate the
         timezone'''


### PR DESCRIPTION
Use case: "Resume" previous day's historical session in today's intraday live trading. So that long period indicators don't need to accumulate several hours for strategies to begin.