### PR TITLE
Python3 compat

### DIFF
--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -35,7 +35,7 @@ import ib.opt as ibopt
 
 from backtrader import TimeFrame, Position
 from backtrader.metabase import MetaParams
-from backtrader.utils.py3 import bytes, bstr, queue, with_metaclass
+from backtrader.utils.py3 import bytes, bstr, queue, with_metaclass, long
 from backtrader.utils import AutoDict
 
 bytes = bstr  # py2/3 need for ibpy

--- a/backtrader/utils/py3.py
+++ b/backtrader/utils/py3.py
@@ -46,6 +46,7 @@ if PY2:
     map = itertools.imap
     range = xrange
     zip = itertools.izip
+    long = long
 
     cmp = cmp
 

--- a/backtrader/utils/py3.py
+++ b/backtrader/utils/py3.py
@@ -90,6 +90,7 @@ else:
     map = map
     range = range
     zip = zip
+    long = int
 
     def cmp(a, b): return (a > b) - (a < b)
 


### PR DESCRIPTION
This is a straightforward response to this line

https://github.com/mementum/backtrader/blob/5cbd0d41/backtrader/stores/ibstore.py#L53

Either this is needed or change that line. Can we do without `long` in `ibstore.py`?