### PR TITLE
Use `position` to get position price instead of `updatePortfolio`

### DIFF
--- a/backtrader/brokers/ibbroker.py
+++ b/backtrader/brokers/ibbroker.py
@@ -260,6 +260,7 @@ class IBBroker(with_metaclass(MetaIBBroker, BrokerBase)):
 
         if self.ib.connected():
             self.ib.reqAccountUpdates()
+            self.ib.reqPositions()
             self.startingcash = self.cash = self.ib.get_acc_cash()
             self.startingvalue = self.value = self.ib.get_acc_value()
         else:

--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -1270,7 +1270,7 @@ class IBStore(with_metaclass(MetaSingleton, object)):
     def position(self, msg):
         '''Receive event positions'''
         with self._lock_pos:
-            price = msg.avgCost / float(m.contract.m_multiplier or 1)
+            price = msg.avgCost / float(msg.contract.m_multiplier or 1)
             con_id = msg.contract.m_conId
 
             if con_id not in self.positions:

--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -1298,9 +1298,6 @@ class IBStore(with_metaclass(MetaSingleton, object)):
 
         self.conn.reqAccountUpdates(subscribe, bytes(account))
 
-    def reqPositions():
-        self.conn.reqPositions()
-
     @ibregister
     def accountDownloadEnd(self, msg):
         # Signals the end of an account update

--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -1274,11 +1274,11 @@ class IBStore(with_metaclass(MetaSingleton, object)):
             con_id = msg.contract.m_conId
 
             if con_id not in self.positions:
-                self.positions[con_id] = Position(msg.position, price)
+                self.positions[con_id] = Position(msg.pos, price)
             else:
                 position = self.positions[con_id]
 
-                if not position.fix(msg.position, price):
+                if not position.fix(msg.pos, price):
                     err = ('The current calculated position and '
                            'the position reported by the broker do not match. '
                            'Operation can continue, but the trades '

--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -1275,16 +1275,16 @@ class IBStore(with_metaclass(MetaSingleton, object)):
 
             if con_id not in self.positions:
                 self.positions[con_id] = Position(msg.position, price)
+            else:
+                position = self.positions[con_id]
 
-            position = self.positions[con_id]
+                if not position.fix(msg.position, price):
+                    err = ('The current calculated position and '
+                           'the position reported by the broker do not match. '
+                           'Operation can continue, but the trades '
+                           'calculated in the strategy may be wrong')
 
-            if not position.fix(msg.position, price):
-                err = ('The current calculated position and '
-                       'the position reported by the broker do not match. '
-                       'Operation can continue, but the trades '
-                       'calculated in the strategy may be wrong')
-
-                self.notifs.put((err, (), {}))
+                    self.notifs.put((err, (), {}))
 
     def reqAccountUpdates(self, subscribe=True, account=None):
         '''Proxy to reqAccountUpdates

--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -1278,6 +1278,10 @@ class IBStore(with_metaclass(MetaSingleton, object)):
             else:
                 self.positions[con_id] = Position(msg.pos, price)
 
+    @ibregister
+    def positionEnd(self, msg):
+        self.conn.cancelPositions()
+
     def reqAccountUpdates(self, subscribe=True, account=None):
         '''Proxy to reqAccountUpdates
 
@@ -1313,6 +1317,7 @@ class IBStore(with_metaclass(MetaSingleton, object)):
             else:
                 con_id = msg.contract.m_conId
                 if con_id in self.positions and self.positions[con_id].size != msg.position:
+                    self.positions[con_id].update(msg.position, self.positions[con_id].price)
                     err = ('The current calculated position and '
                            'the position reported by the broker do not match. '
                            'Operation can continue, but the trades '


### PR DESCRIPTION
`averageCost` in `updatePortfolio` includes commission so it would give the strategy the wrong `position.price`

See https://www.interactivebrokers.com.hk/en/software/api/apiguide/java/updateportfolio.htm