### PR TITLE
Fix OCO child order cancel

### DIFF
--- a/backtrader/brokers/bbroker.py
+++ b/backtrader/brokers/bbroker.py
@@ -476,7 +476,7 @@ class BackBroker(bt.BrokerBase):
     def _ocoize(self, order, oco):
         oref = order.ref
         if oco is None:
-            self._ocos[oref] = None  # no parent
+            self._ocos[oref] = oref  # current order is parent
             self._ocol[oref].append(oref)  # create ocogroup
         else:
             ocoref = self._ocos[oco.ref]  # ref to group leader


### PR DESCRIPTION
Hi mementum,
OCO feature is great addition to the platform, thanks for developing it.

I tried the functionality and in my case child order is not able to cancel parent, vise versa works.

Could you please take a look at the fix in this PR, to me looks like it is working but it might be breaking something else.

Thanks,
Dimitar
