### PR TITLE
Allow saving figures, instead of showing them.

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -693,7 +693,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
     broker = property(getbroker, setbroker)
 
     def plot(self, plotter=None, numfigs=1, iplot=True, start=None, end=None,
-             savefig=False, figfilename='backtrader-plot-%i.pdf',
+             savefig=False, figfilename='backtrader-plot-%i.png',
              **kwargs):
         '''
         Plots the strategies inside cerebro

--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -693,6 +693,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
     broker = property(getbroker, setbroker)
 
     def plot(self, plotter=None, numfigs=1, iplot=True, start=None, end=None,
+             savefig=False, figfilename='backtrader-plot-%i.pdf',
              **kwargs):
         '''
         Plots the strategies inside cerebro
@@ -740,7 +741,10 @@ class Cerebro(with_metaclass(MetaParams, object)):
 
                 figs.append(rfig)
 
-            plotter.show()
+            if savefig:
+                plotter.savefig(figfilename % len(figs))
+            else:
+                plotter.show()
         return figs
 
     def __call__(self, iterstrat):

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -755,7 +755,7 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
     def show(self):
         self.mpyplot.show()
 
-    def savefig(self, filename='backtrader-plot.pdf'):
+    def savefig(self, filename='backtrader-plot.png'):
         fig = self.mpyplot.gcf()
         fig.set_size_inches(16, 9)
         self.mpyplot.savefig(filename, dpi=300, bbox_inches='tight')

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -755,6 +755,11 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
     def show(self):
         self.mpyplot.show()
 
+    def savefig(self, filename='backtrader-plot.pdf'):
+        fig = self.mpyplot.gcf()
+        fig.set_size_inches(16, 9)
+        self.mpyplot.savefig(filename, dpi=300, bbox_inches='tight')
+
     def sortdataindicators(self, strategy):
         # These lists/dictionaries hold the subplots that go above each data
         self.dplotstop = list()


### PR DESCRIPTION
For example, one can pass --plot savefig=True to bt-run script to
store all figures as backtrader-plot-N.pdf files. Useful for running
backtests non-interactively and saving plots.

Currently stores as PDF, but other naming pattern and file extensions
can be used (e.g. 'plot-%i.png'). Current format, figure size, and dpi
optimised for widescreen on-screen viewing.