### PR TITLE
Add support for Metatrader4 csv format.

### DIFF
--- a/backtrader/btrun/btrun.py
+++ b/backtrader/btrun/btrun.py
@@ -37,6 +37,7 @@ DATAFORMATS = dict(
     vchartcsv=bt.feeds.VChartCSVData,
     vcfile=bt.feeds.VChartFile,
     sierracsv=bt.feeds.SierraChartCSVData,
+    mt4csv=bt.feeds.MT4CSVData,
     yahoocsv=bt.feeds.YahooFinanceCSVData,
     yahoocsv_unreversed=bt.feeds.YahooFinanceCSVData,
     yahoo=bt.feeds.YahooFinanceData,

--- a/backtrader/feeds/mt4csv.py
+++ b/backtrader/feeds/mt4csv.py
@@ -3,6 +3,7 @@
 ###############################################################################
 #
 # Copyright (C) 2015, 2016, 2017 Daniel Rodriguez
+# Copyright (C) 2017 Dimitri John Ledkov
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,32 +23,30 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 
-from .csvgeneric import *
-from .btcsv import *
-from .vchartcsv import *
-from .vchart import *
-from .yahoo import *
-from .sierrachart import *
-from .mt4csv import *
-from .pandafeed import *
-from .influxfeed import *
-try:
-    from .ibdata import *
-except ImportError:
-    pass  # The user may not have ibpy installed
-
-try:
-    from .vcdata import *
-except ImportError:
-    pass  # The user may not have something installed
-
-try:
-    from .oanda import OandaData
-except ImportError:
-    pass  # The user may not have something installed
+from . import GenericCSVData
 
 
-from .vchartfile import VChartFile
+class MT4CSVData(GenericCSVData):
+    '''
+    Parses a `Metatrader4 <https://www.metaquotes.net/en/metatrader4>`_ History
+    center CSV exported file.
 
-from .rollover import RollOver
-from .chainer import Chainer
+    Specific parameters (or specific meaning):
+
+      - ``dataname``: The filename to parse or a file-like object
+
+      - Uses GenericCSVData and simply modifies the params
+    '''
+
+    params = (
+        ('dtformat', '%Y.%m.%d'),
+        ('tmformat', '%H:%M'),
+        ('datetime', 0),
+        ('time',  1),
+        ('open',  2),
+        ('high',  3),
+        ('low',   4),
+        ('close', 5),
+        ('volume', 6),
+        ('openinterest', -1),
+    )

--- a/docs2/automated-bt-run/automated-bt-run.rst
+++ b/docs2/automated-bt-run/automated-bt-run.rst
@@ -420,7 +420,7 @@ Directly from the script::
 
   $ btrun --help
   usage: btrun-script.py [-h] --data DATA [--cerebro [kwargs]] [--nostdstats]
-                         [--format {yahoocsv_unreversed,vchart,vchartcsv,yahoo,ibdata,sierracsv,yahoocsv,btcsv,vcdata}]
+                         [--format {yahoocsv_unreversed,vchart,vchartcsv,yahoo,mt4csv,ibdata,sierracsv,yahoocsv,btcsv,vcdata}]
                          [--fromdate FROMDATE] [--todate TODATE]
                          [--timeframe {microseconds,seconds,weeks,months,minutes,days,years}]
                          [--compression COMPRESSION]
@@ -483,7 +483,7 @@ Directly from the script::
                             - oldbuysell (default False)
                             - tradehistory (default False)
     --nostdstats          Disable the standard statistics observers
-    --format {yahoocsv_unreversed,vchart,vchartcsv,yahoo,ibdata,sierracsv,yahoocsv,btcsv,vcdata}, --csvformat {yahoocsv_unreversed,vchart,vchartcsv,yahoo,ibdata,sierracsv,yahoocsv,btcsv,vcdata}, -c {yahoocsv_unreversed,vchart,vchartcsv,yahoo,ibdata,sierracsv,yahoocsv,btcsv,vcdata}
+    --format {yahoocsv_unreversed,vchart,vchartcsv,yahoo,mt4csv,ibdata,sierracsv,yahoocsv,btcsv,vcdata}, --csvformat {yahoocsv_unreversed,vchart,vchartcsv,yahoo,mt4csv,ibdata,sierracsv,yahoocsv,btcsv,vcdata}, -c {yahoocsv_unreversed,vchart,vchartcsv,yahoo,mt4csv,ibdata,sierracsv,yahoocsv,btcsv,vcdata}
                           CSV Format
     --fromdate FROMDATE, -f FROMDATE
                           Starting date in YYYY-MM-DD[THH:MM:SS] format

--- a/tools/rewrite-data.py
+++ b/tools/rewrite-data.py
@@ -39,6 +39,7 @@ DATAFORMATS = dict(
     vcfile=bt.feeds.VChartFile,
     ibdata=bt.feeds.IBData,
     sierracsv=bt.feeds.SierraChartCSVData,
+    mt4csv=bt.feeds.MT4CSVData,
     yahoocsv=bt.feeds.YahooFinanceCSVData,
     yahoocsv_unreversed=bt.feeds.YahooFinanceCSVData,
     yahoo=bt.feeds.YahooFinanceData,


### PR DESCRIPTION
Whilst it is a simple variation on the GenericCSVData, it is very
useful to have as a command-line option in btrun script. There are
many brokers that use Metatrader platforms for trading, and most
brokers allow exporting CSV files from the history centre with
historical quotes as provided by the broker.