### PR TITLE
Timer: Weekdays filter not working due to weekcarry not initialized and typo

### DIFF
--- a/backtrader/timer.py
+++ b/backtrader/timer.py
@@ -47,6 +47,7 @@ class Timer(with_metaclass(MetaParams, object)):
         ('offset', timedelta()),
         ('repeat', timedelta()),
         ('weekdays', []),
+        ('weekcarry', False),
         ('monthdays', []),
         ('monthcarry', True),
         ('allow', None),  # callable that allows a timer to take place
@@ -127,7 +128,7 @@ class Timer(with_metaclass(MetaParams, object)):
             daycarry = self.p.weekcarry and bool(mask)
             self._weekmask = mask = collections.deque(self.p.weekdays)
 
-        dc = bisect.bisect_left(mask, dwkay)  # "left" for days before dday
+        dc = bisect.bisect_left(mask, dwkday)  # "left" for days before dday
         daycarry = daycarry or (self.p.weekcarry and dc > 0)
         curday = bisect.bisect_right(mask, dwkday, lo=dc) > 0  # check dday
         dc += curday


### PR DESCRIPTION
**Danger**! Newbie in python

While playing with `samples/timers/scheduled.py`  and trying to run timer only on fridays:
```diff
diff --git a/samples/timers/scheduled.py b/samples/timers/scheduled.py
index 497a2fe..3b4cab5 100644
--- a/samples/timers/scheduled.py
+++ b/samples/timers/scheduled.py
@@ -34,7 +34,7 @@ class St(bt.Strategy):
         cheat=False,
         offset=datetime.timedelta(),
         repeat=datetime.timedelta(),
-        weekdays=[],
+        weekdays=[5],
     )
 
     def __init__(self):
```
I got the following **error**: 

```python
Traceback (most recent call last):
  File "scheduled.py", line 164, in <module>
    runstrat()
  File "scheduled.py", line 120, in runstrat
    cerebro.run(**eval('dict(' + args.cerebro + ')'))
  File "/usr/lib/python3.4/site-packages/backtrader/cerebro.py", line 1070, in run
    runstrat = self.runstrategies(iterstrat)
  File "/usr/lib/python3.4/site-packages/backtrader/cerebro.py", line 1227, in runstrategies
    self._runonce(runstrats)
  File "/usr/lib/python3.4/site-packages/backtrader/cerebro.py", line 1619, in _runonce
    self._check_timers(runstrats, dt0, cheat=False)
  File "/usr/lib/python3.4/site-packages/backtrader/cerebro.py", line 1631, in _check_timers
    if not t.check(dt0):
  File "/usr/lib/python3.4/site-packages/backtrader/timer.py", line 158, in check
    ret = self._check_week(ddate)
  File "/usr/lib/python3.4/site-packages/backtrader/timer.py", line 127, in _check_week
    daycarry = self.p.weekcarry and bool(mask)
AttributeError: 'AutoInfoClass_Timer' object has no attribute 'weekcarry'
```

Thanks @mementum for this great framework!