### PR TITLE
Headless plot

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -924,7 +924,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
             for si, strat in enumerate(stratlist):
                 rfig = plotter.plot(strat, figid=si * 100,
                                     numfigs=numfigs, iplot=iplot,
-                                    start=start, end=end)
+                                    start=start, end=end, savefig=savefig)
                 # pfillers=pfillers2)
 
                 figs.append(rfig)

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -114,13 +114,16 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
                       **kwargs)
 
     def plot(self, strategy, figid=0, numfigs=1, iplot=True,
-             start=None, end=None, **kwargs):
+             start=None, end=None, savefig=False, **kwargs):
         # pfillers={}):
         if not strategy.datas:
             return
 
         if not len(strategy):
             return
+
+        if savefig:
+            matplotlib.use('agg')
 
         if iplot:
             if 'ipykernel' in sys.modules:


### PR DESCRIPTION
If we want to save the plot, assume that it is being done headless.  This allows us to 'savefig' on a remove machine that doesn't have X11 or the like installed.