### PR TITLE
Fixed .ix is deprecated

### DIFF
--- a/backtrader/feeds/pandafeed.py
+++ b/backtrader/feeds/pandafeed.py
@@ -218,7 +218,7 @@ class PandasData(feed.DataBase):
             line = getattr(self.lines, datafield)
 
             # indexing for pandas: 1st is colum, then row
-            line[0] = self.p.dataname.loc[self.p.dataname.index[self._idx], colindex]
+            line[0] = self.p.dataname.iloc[self._idx, self.p.dataname.columns.get_loc(colindex)]
 
         # datetime conversion
         coldtime = self._colmapping[self.datafields[0]]

--- a/backtrader/feeds/pandafeed.py
+++ b/backtrader/feeds/pandafeed.py
@@ -218,7 +218,7 @@ class PandasData(feed.DataBase):
             line = getattr(self.lines, datafield)
 
             # indexing for pandas: 1st is colum, then row
-            line[0] = self.p.dataname.ix[self._idx, colindex]
+            line[0] = self.p.dataname.loc[self.p.dataname.index[self._idx], colindex]
 
         # datetime conversion
         coldtime = self._colmapping[self.datafields[0]]


### PR DESCRIPTION
Fixed `.ix is deprecated.`

Message is below
```
/site-packages/backtrader/feeds/pandafeed.py:221: DeprecationWarning: 
.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing

See the documentation here:
http://pandas.pydata.org/pandas-docs/stable/indexing.html#deprecate_ix
  line[0] = self.p.dataname.ix[self._idx, colindex]
/site-packages/pandas/core/indexing.py:992: DeprecationWarning: 
.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing

See the documentation here:
http://pandas.pydata.org/pandas-docs/stable/indexing.html#deprecate_ix
  return getattr(section, self.name)[new_key]
```