### PR TITLE
Fixed SQN division by zero rare bug

### DIFF
--- a/backtrader/analyzers/sqn.py
+++ b/backtrader/analyzers/sqn.py
@@ -74,7 +74,12 @@ class SQN(Analyzer):
         if self.count > 1:
             pnl_av = average(self.pnl)
             pnl_stddev = standarddev(self.pnl)
-            sqn = math.sqrt(len(self.pnl)) * pnl_av / pnl_stddev
+            
+            # Abort calc if stddev is 0, else will get division by zero error.
+            if pnl_stddev == 0:
+                sqn = None  # Cannot calculate.
+            else:
+                sqn = math.sqrt(len(self.pnl)) * pnl_av / pnl_stddev
         else:
             sqn = 0
 


### PR DESCRIPTION
SQN uses standard deviation in its calculation. In some rare cases,
there may be standard deviation of zero (More likely to occur in a
system with low number of trades).
Instead of crashing with 'divide by zero' exception. Better to simple
return a value of 'None'.