### PR TITLE
Added 'Size' to logged buy, also fixed typo

### DIFF
--- a/docs2/quickstart/quickstart08.py
+++ b/docs2/quickstart/quickstart08.py
@@ -55,12 +55,13 @@ class TestStrategy(bt.Strategy):
             return
 
         # Check if an order has been completed
-        # Attention: broker could reject order if not enougth cash
+        # Attention: broker could reject order if not enough cash
         if order.status in [order.Completed]:
             if order.isbuy():
                 self.log(
-                    'BUY EXECUTED, Price: %.2f, Cost: %.2f, Comm %.2f' %
-                    (order.executed.price,
+                    'BUY EXECUTED, Size: %d, Price: %.2f, Cost: %.2f, Comm %.2f' %
+                    (self.sizer.getsizing(self.data, order.isbuy()),
+                     order.executed.price,
                      order.executed.value,
                      order.executed.comm))
 

--- a/docs2/quickstart/quickstart09.py
+++ b/docs2/quickstart/quickstart09.py
@@ -59,12 +59,13 @@ class TestStrategy(bt.Strategy):
             return
 
         # Check if an order has been completed
-        # Attention: broker could reject order if not enougth cash
+        # Attention: broker could reject order if not enough cash
         if order.status in [order.Completed]:
             if order.isbuy():
                 self.log(
-                    'BUY EXECUTED, Price: %.2f, Cost: %.2f, Comm %.2f' %
-                    (order.executed.price,
+                    'BUY EXECUTED, Size: %d, Price: %.2f, Cost: %.2f, Comm %.2f' %
+                    (self.sizer.getsizing(self.data, order.isbuy()),
+                     order.executed.price,
                      order.executed.value,
                      order.executed.comm))
 


### PR DESCRIPTION
The quickstart shows the output including the size:
`2000-01-06T00:00:00, BUY EXECUTED, Size 10, Price: 23.61, Cost: 236.10, Commission 0.24`