### PR TITLE
adding extra day before dtcmp calc

### DIFF
--- a/backtrader/analyzer.py
+++ b/backtrader/analyzer.py
@@ -434,11 +434,13 @@ class TimeFrameAnalyzerBase(with_metaclass(MetaTimeFrameAnalyzerBase,
             seconds=self.timeframe == TimeFrame.Seconds,
             microseconds=self.timeframe == TimeFrame.MicroSeconds)
 
+        # Add extra day if present
+        if extradays:
+            dt += datetime.timedelta(days=extradays)
+
         # Replace intraday parts with the calculated ones and update it
         dtcmp = dt.replace(hour=ph, minute=pm, second=ps, microsecond=pus)
         dtcmp -= tadjust
-        if extradays:
-            dt += datetime.timedelta(days=extradays)
         dtkey = dtcmp
 
         return dtcmp, dtkey


### PR DESCRIPTION
I think we came across a bug with the analyzers when running on lower-than-daily timeframes. It seems that the `extradays` added in c31545d900b257b91e26747b82d62e5ca118733a currently have no effect. 