### PR TITLE
fixing time.clock for python>=3.8

### DIFF
--- a/tests/test_analyzer-sqn.py
+++ b/tests/test_analyzer-sqn.py
@@ -22,6 +22,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import time
+try:
+    time_clock = time.clock
+except:  # py38
+    time_clock = time.process_time
+
 
 import testcommon
 
@@ -92,7 +97,7 @@ class TestStrategy(bt.Strategy):
             self.log('Starting portfolio value: %.2f' % self.broker.getvalue(),
                      nodate=True)
 
-        self.tstart = time.clock()
+        self.tstart = time_clock()
 
         self.buycreate = list()
         self.sellcreate = list()
@@ -101,7 +106,7 @@ class TestStrategy(bt.Strategy):
         self.tradecount = 0
 
     def stop(self):
-        tused = time.clock() - self.tstart
+        tused = time_clock() - self.tstart
         if self.p.printdata:
             self.log('Time used: %s' % str(tused))
             self.log('Final portfolio value: %.2f' % self.broker.getvalue())

--- a/tests/test_analyzer-sqn.py
+++ b/tests/test_analyzer-sqn.py
@@ -23,9 +23,9 @@ from __future__ import (absolute_import, division, print_function,
 
 import time
 try:
-    time_clock = time.clock
-except:  # py38
     time_clock = time.process_time
+except:
+    time_clock = time.clock
 
 
 import testcommon

--- a/tests/test_analyzer-timereturn.py
+++ b/tests/test_analyzer-timereturn.py
@@ -22,6 +22,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import time
+try:
+    time_clock = time.clock
+except:  # py38
+    time_clock = time.process_time
 
 import testcommon
 
@@ -88,7 +92,7 @@ class TestStrategy(bt.Strategy):
             self.log('Starting portfolio value: %.2f' % self.broker.getvalue(),
                      nodate=True)
 
-        self.tstart = time.clock()
+        self.tstart = time_clock()
 
         self.buycreate = list()
         self.sellcreate = list()
@@ -96,7 +100,7 @@ class TestStrategy(bt.Strategy):
         self.sellexec = list()
 
     def stop(self):
-        tused = time.clock() - self.tstart
+        tused = time_clock() - self.tstart
         if self.p.printdata:
             self.log('Time used: %s' % str(tused))
             self.log('Final portfolio value: %.2f' % self.broker.getvalue())

--- a/tests/test_analyzer-timereturn.py
+++ b/tests/test_analyzer-timereturn.py
@@ -23,9 +23,9 @@ from __future__ import (absolute_import, division, print_function,
 
 import time
 try:
-    time_clock = time.clock
-except:  # py38
     time_clock = time.process_time
+except:
+    time_clock = time.clock
 
 import testcommon
 

--- a/tests/test_strategy_optimized.py
+++ b/tests/test_strategy_optimized.py
@@ -23,7 +23,10 @@ from __future__ import (absolute_import, division, print_function,
 
 import itertools
 import time
-
+try:
+    time_clock = time.clock
+except:  # py38
+    time_clock = time.process_time
 
 import testcommon
 
@@ -78,14 +81,14 @@ class TestStrategy(bt.Strategy):
 
     def start(self):
         self.broker.setcommission(commission=2.0, mult=10.0, margin=1000.0)
-        self.tstart = time.clock()
+        self.tstart = time_clock()
         self.buy_create_idx = itertools.count()
 
     def stop(self):
         global _chkvalues
         global _chkcash
 
-        tused = time.clock() - self.tstart
+        tused = time_clock() - self.tstart
         if self.p.printdata:
             self.log(('Time used: %s  - Period % d - '
                       'Start value: %.2f - End value: %.2f') %

--- a/tests/test_strategy_optimized.py
+++ b/tests/test_strategy_optimized.py
@@ -24,9 +24,9 @@ from __future__ import (absolute_import, division, print_function,
 import itertools
 import time
 try:
-    time_clock = time.clock
-except:  # py38
     time_clock = time.process_time
+except:
+    time_clock = time.clock
 
 import testcommon
 

--- a/tests/test_strategy_unoptimized.py
+++ b/tests/test_strategy_unoptimized.py
@@ -22,6 +22,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import time
+try:
+    time_clock = time.clock
+except:  # py38
+    time_clock = time.process_time
 
 import testcommon
 
@@ -107,7 +111,7 @@ class TestStrategy(bt.Strategy):
             self.log('Starting portfolio value: %.2f' % self.broker.getvalue(),
                      nodate=True)
 
-        self.tstart = time.clock()
+        self.tstart = time_clock()
 
         self.buycreate = list()
         self.sellcreate = list()
@@ -115,7 +119,7 @@ class TestStrategy(bt.Strategy):
         self.sellexec = list()
 
     def stop(self):
-        tused = time.clock() - self.tstart
+        tused = time_clock() - self.tstart
         if self.p.printdata:
             self.log('Time used: %s' % str(tused))
             self.log('Final portfolio value: %.2f' % self.broker.getvalue())

--- a/tests/test_strategy_unoptimized.py
+++ b/tests/test_strategy_unoptimized.py
@@ -23,9 +23,9 @@ from __future__ import (absolute_import, division, print_function,
 
 import time
 try:
-    time_clock = time.clock
-except:  # py38
     time_clock = time.process_time
+except:
+    time_clock = time.clock
 
 import testcommon
 


### PR DESCRIPTION
Hi all.

I see that time.clock is deprecated in py3.8 and some tests are failing as a result. Please find adjustments for this below referencing time.process_time for Python 3.8.

Happy to make adjustments if you need.

Cheers,
Simon.