### PR TITLE
IB: add support for ASK quotes for CASH assets

### DIFF
--- a/backtrader/feeds/ibdata.py
+++ b/backtrader/feeds/ibdata.py
@@ -113,6 +113,8 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
           - 'BID' for CASH assets
           - 'TRADES' for any other
 
+        Use 'ASK' for the Ask quote of cash assets
+        
         Check the IB API docs if another value is wished
 
       - ``rtbar`` (default: ``False``)
@@ -412,7 +414,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
             return
 
         if self._usertvol:
-            self.qlive = self.ib.reqMktData(self.contract)
+            self.qlive = self.ib.reqMktData(self.contract, self.p.what)
         else:
             self.qlive = self.ib.reqRealTimeBars(self.contract)
 

--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -759,6 +759,8 @@ class IBStore(with_metaclass(MetaSingleton, object)):
             self.iscash[tickerId] = True
             if not what:
                 what = 'BID'  # TRADES doesn't work
+            elif what is 'ASK':
+                self.iscash[tickerId] = 2
         else:
             what = what or 'TRADES'
 
@@ -827,7 +829,7 @@ class IBStore(with_metaclass(MetaSingleton, object)):
 
             self.cancelQueue(q, True)
 
-    def reqMktData(self, contract):
+    def reqMktData(self, contract, what=None):
         '''Creates a MarketData subscription
 
         Params:
@@ -843,7 +845,9 @@ class IBStore(with_metaclass(MetaSingleton, object)):
         if contract.m_secType in ['CASH', 'CFD']:
             self.iscash[tickerId] = True
             ticks = ''  # cash markets do not get RTVOLUME
-
+            if what is 'ASK':
+                self.iscash[tickerId] = 2
+                
         # q.put(None)  # to kickstart backfilling
         # Can request 233 also for cash ... nothing will arrive
         self.conn.reqMktData(tickerId, contract, bytes(ticks), False)

--- a/samples/ib-cash-bid-ask/ib-cash-bid-ask.py
+++ b/samples/ib-cash-bid-ask/ib-cash-bid-ask.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2018 Daniel Rodriguez
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+# When setting the parameter "what='ASK'" the quoted price for Ask will be used from the incoming messages (field 2) instead of the default Bid price (field 1).
+
+# BID: <tickPrice tickerId=16777217, field=1, price=1.11582, canAutoExecute=1>
+# ASK: <tickPrice tickerId=16777219, field=2, price=1.11583, canAutoExecute=1>
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import backtrader as bt
+import datetime
+
+
+class St(bt.Strategy):
+    def logdata(self):
+        txt = []
+        txt.append('{}'.format(len(self)))
+        txt.append('{}'.format(self.data.datetime.datetime(0).isoformat()))
+        txt.append(' open BID: ' + '{}'.format(self.datas[0].open[0]))
+        txt.append(' open ASK: ' + '{}'.format(self.datas[1].open[0]))
+        txt.append(' high BID: ' + '{}'.format(self.datas[0].high[0]))
+        txt.append(' high ASK: ' + '{}'.format(self.datas[1].high[0]))
+        txt.append(' low BID: ' + '{}'.format(self.datas[0].low[0]))
+        txt.append(' low ASK: ' + '{}'.format(self.datas[1].low[0]))
+        txt.append(' close BID: ' + '{}'.format(self.datas[0].close[0]))
+        txt.append(' close ASK: ' + '{}'.format(self.datas[1].close[0]))
+        txt.append(' volume: ' + '{:.2f}'.format(self.data.volume[0]))
+        print(','.join(txt))
+
+    data_live = False
+
+    def notify_data(self, data, status, *args, **kwargs):
+        print('*' * 5, 'DATA NOTIF:', data._getstatusname(status), *args)
+        if self.datas[0]._laststatus == self.datas[0].LIVE and self.datas[1]._laststatus == self.datas[1].LIVE:
+            self.data_live = True
+
+    # def notify_order(self, order):
+    #     if order.status == order.Completed:
+    #         buysell = 'BUY ' if order.isbuy() else 'SELL'
+    #         txt = '{} {}@{}'.format(buysell, order.executed.size,
+    #                                 order.executed.price)
+    #         print(txt)
+
+    # bought = 0
+    # sold = 0
+
+    def next(self):
+        self.logdata()
+        if not self.data_live:
+            return
+
+        # if not self.bought:
+        #     self.bought = len(self)  # keep entry bar
+        #     self.buy()
+        # elif not self.sold:
+        #     if len(self) == (self.bought + 3):
+        #         self.sell()
+
+
+ib_symbol = 'EUR.USD-CASH-IDEALPRO'
+compression = 5
+
+def run(args=None):
+    cerebro = bt.Cerebro(stdstats=False)
+    store = bt.stores.IBStore(port=7497,
+                              # _debug=True
+                              )
+
+    data0 = store.getdata(dataname=ib_symbol,
+                          timeframe=bt.TimeFrame.Ticks,
+                          )
+    cerebro.resampledata(data0,
+                         timeframe=bt.TimeFrame.Seconds,
+                         compression=compression
+                         )
+
+    data1 = store.getdata(dataname=ib_symbol,
+                          timeframe=bt.TimeFrame.Ticks,
+                          what='ASK'
+                          )
+    cerebro.resampledata(data1,
+                         timeframe=bt.TimeFrame.Seconds,
+                         compression=compression
+                         )
+
+    cerebro.broker = store.getbroker()
+    cerebro.addstrategy(St)
+    cerebro.run()
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
These changes add support for grabbing 'ASK' quotes from the TWS.

When setting the parameter "what='ASK'" the quoted price for Ask will be used from the incoming messages (field 2) instead of the default Bid price (field 1).

Incoming messages example:
BID field 1: `<tickPrice tickerId=16777217, field=1, price=1.11582, canAutoExecute=1>`
ASK field 2: `<tickPrice tickerId=16777219, field=2, price=1.11583, canAutoExecute=1>`

To see the changes at work, check out the example at https://github.com/freedumb2000/backtrader/blob/IB-ASK/samples/ib-cash-bid-ask/ib-cash-bid-ask.py