### PR TITLE
Fixing the issue with TWS API Bust events (err code 10225)

### DIFF
--- a/backtrader/feeds/ibdata.py
+++ b/backtrader/feeds/ibdata.py
@@ -363,6 +363,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
         else:
             self._state = self._ST_START  # initial state for _load
         self._statelivereconn = False  # if reconnecting in live state
+        self._subcription_valid = False  # subscription state
         self._storedmsg = dict()  # keep pending live message (under None)
 
         if not self.ib.connected():
@@ -408,7 +409,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
 
     def reqdata(self):
         '''request real-time data. checks cash vs non-cash) and param useRT'''
-        if self.contract is None:
+        if self.contract is None or self._subcription_valid:
             return
 
         if self._usertvol:
@@ -416,6 +417,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
         else:
             self.qlive = self.ib.reqRealTimeBars(self.contract)
 
+        self._subcription_valid = True
         return self.qlive
 
     def canceldata(self):
@@ -444,7 +446,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
                     if True:
                         return None
 
-                    # Code invalidated until further checking is done
+                # Code invalidated until further checking is done
                     if not self._statelivereconn:
                         return None  # indicate timeout situation
 
@@ -471,6 +473,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
                     continue  # to reenter the loop and hit st_historback
 
                 if msg is None:  # Conn broken during historical/backfilling
+                    self._subcription_valid = False
                     self.put_notification(self.CONNBROKEN)
                     # Try to reconnect
                     if not self.ib.reconnect(resub=True):
@@ -487,6 +490,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
                 elif msg == -1100:  # conn broken
                     # Tell to wait for a message to do a backfill
                     # self._state = self._ST_DISCONN
+                    self._subcription_valid = False
                     self._statelivereconn = self.p.backfill
                     continue
 
@@ -498,6 +502,14 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
 
                 elif msg == -1101:  # conn broken/restored tickerId gone
                     # The message may be duplicated
+                    self._subcription_valid = False
+                    if not self._statelivereconn:
+                        self._statelivereconn = self.p.backfill
+                        self.reqdata()  # resubscribe
+                    continue
+
+                elif msg == -10225:  # Bust event occurred, current subscription is deactivated.
+                    self._subcription_valid = False
                     if not self._statelivereconn:
                         self._statelivereconn = self.p.backfill
                         self.reqdata()  # resubscribe
@@ -559,14 +571,17 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
                 msg = self.qhist.get()
                 if msg is None:  # Conn broken during historical/backfilling
                     # Situation not managed. Simply bail out
+                    self._subcription_valid = False
                     self.put_notification(self.DISCONNECTED)
                     return False  # error management cancelled the queue
 
                 elif msg == -354:  # Data not subscribed
+                    self._subcription_valid = False
                     self.put_notification(self.NOTSUBSCRIBED)
                     return False
 
                 elif msg == -420:  # No permissions for the data
+                    self._subcription_valid = False
                     self.put_notification(self.NOTSUBSCRIBED)
                     return False
 

--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -480,6 +480,16 @@ class IBStore(with_metaclass(MetaSingleton, object)):
                 q.put(-msg.errorCode)
                 self.cancelQueue(q)
 
+        elif msg.errorCode == 10225:
+            # 10225-Bust event occurred, current subscription is deactivated.
+            # Please resubscribe real-time bars immediately.
+            try:
+                q = self.qs[msg.id]
+            except KeyError:
+                pass  # should not happend but it can
+            else:
+                q.put(-msg.errorCode)
+
         elif msg.errorCode == 326:  # not recoverable, clientId in use
             self.dontreconnect = True
             self.conn.disconnect()


### PR DESCRIPTION
This PR fixes the issue with realtimeBar subscriptions that stop working due to the bust events. 

Up to the TWS API v972, IB realtimeBar subscriptions could stop working during the trading session and no error notification was sent to the application. This happens because of what's called 'busts' events.

Quoting the response in "TWS API Users Group" question: 

"The busts occur when the datastream is interrupted or modified in the middle of a bar and the subscription is cancelled by the backend. They should be relatively uncommon but unfortunately no can't be avoided completely"


In TWS API v978,a special error code was added to notify the application about the bust event so that the subscription could be renewed. Below is the example of such error message (from TWS Gateway API logs):

```
15:24:00:896 -> 4-2-16777221-10225-Bust event occurred, current subscription is deactivated. Please resubscribe real-time bars immediately.-
```
