### PR TITLE
Changed file initiation for WriterFile to make it work under multi-process optimization

### DIFF
--- a/backtrader/writer.py
+++ b/backtrader/writer.py
@@ -122,7 +122,11 @@ class WriterFile(WriterBase):
             self.writelineseparator()
             self.writeiterable(self.headers, counter='Id')
 
+        self.buffer = []
+
     def stop(self):
+        self.out.write("\n".join(self.buffer) + "\n")
+        self.buffer = None
         if self.close_out:
             self.out.close()
             self.out = None
@@ -153,7 +157,7 @@ class WriterFile(WriterBase):
         self.writeline(line)
 
     def writeline(self, line):
-        self.out.write(line + '\n')
+        self.buffer.append(line)
 
     def writelines(self, lines):
         for l in lines:

--- a/backtrader/writer.py
+++ b/backtrader/writer.py
@@ -43,7 +43,10 @@ class WriterFile(WriterBase):
       - ``out`` (default: ``sys.stdout``): output stream to write to
 
         If a string is passed a filename with the content of the parameter will
-        be used
+        be used.
+
+        If you wish to run with ``sys.stdout`` while doing multiprocess optimization, leave it as ``None``, which will
+        automatically initiate ``sys.stdout`` on the child processes.
 
       - ``close_out``  (default: ``False``)
 
@@ -83,7 +86,7 @@ class WriterFile(WriterBase):
 
     '''
     params = (
-        ('out', sys.stdout),
+        ('out', None),
         ('close_out', False),
 
         ('csv', False),
@@ -102,15 +105,19 @@ class WriterFile(WriterBase):
         self.headers = list()
         self.values = list()
 
-        # open file if needed
-        if isinstance(self.p.out, string_types):
-            self.out = open(self.p.out, 'w')
-            self.close_out = True
-        else:
-            self.out = self.p.out
-            self.close_out = self.p.close_out
-
     def start(self):
+        # open file if needed
+        if not hasattr(self, 'out') or not self.out:
+            if self.p.out is None:
+                self.out = sys.stdout
+                self.close_out = False
+            elif isinstance(self.p.out, string_types):
+                self.out = open(self.p.out, 'w')
+                self.close_out = True
+            else:
+                self.out = self.p.out
+                self.close_out = self.p.close_out
+
         if self.p.csv:
             self.writelineseparator()
             self.writeiterable(self.headers, counter='Id')
@@ -118,6 +125,7 @@ class WriterFile(WriterBase):
     def stop(self):
         if self.close_out:
             self.out.close()
+            self.out = None
 
     def next(self):
         if self.p.csv:


### PR DESCRIPTION
`WriterFile` did not work under optimization, since `sys.stdout` can't be serialized. I made `None` default to stdout. Personally, I don't feel like this is correct, since `None` _should_ result in the write not writing anywhere, but that's not really useful. Open to suggestions, perhaps there's a Python trick I'm not aware of.

Also, I have not run the tests, since I'm not familiar with how to do this.