### PR TITLE
Add py38 compatibility for time.clock()

### DIFF
--- a/tests/test_analyzer-sqn.py
+++ b/tests/test_analyzer-sqn.py
@@ -22,6 +22,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import time
+import sys
 
 import testcommon
 
@@ -92,7 +93,10 @@ class TestStrategy(bt.Strategy):
             self.log('Starting portfolio value: %.2f' % self.broker.getvalue(),
                      nodate=True)
 
-        self.tstart = time.clock()
+        if sys.version_info >= (3, 8):
+            self.tstart = time.perf_counter()
+        else:
+            self.tstart = time.clock()
 
         self.buycreate = list()
         self.sellcreate = list()
@@ -101,7 +105,10 @@ class TestStrategy(bt.Strategy):
         self.tradecount = 0
 
     def stop(self):
-        tused = time.clock() - self.tstart
+        if sys.version_info >= (3, 8):
+            tused = time.perf_counter() - self.tstart
+        else:
+            tused = time.clock() - self.tstart
         if self.p.printdata:
             self.log('Time used: %s' % str(tused))
             self.log('Final portfolio value: %.2f' % self.broker.getvalue())

--- a/tests/test_analyzer-timereturn.py
+++ b/tests/test_analyzer-timereturn.py
@@ -22,6 +22,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import time
+import sys
 
 import testcommon
 
@@ -88,7 +89,10 @@ class TestStrategy(bt.Strategy):
             self.log('Starting portfolio value: %.2f' % self.broker.getvalue(),
                      nodate=True)
 
-        self.tstart = time.clock()
+        if sys.version_info >= (3, 8):
+            self.tstart = time.perf_counter()
+        else:
+            self.tstart = time.clock()
 
         self.buycreate = list()
         self.sellcreate = list()
@@ -96,7 +100,10 @@ class TestStrategy(bt.Strategy):
         self.sellexec = list()
 
     def stop(self):
-        tused = time.clock() - self.tstart
+        if sys.version_info >= (3, 8):
+            tused = time.perf_counter() - self.tstart
+        else:
+            tused = time.clock() - self.tstart
         if self.p.printdata:
             self.log('Time used: %s' % str(tused))
             self.log('Final portfolio value: %.2f' % self.broker.getvalue())

--- a/tests/test_strategy_optimized.py
+++ b/tests/test_strategy_optimized.py
@@ -23,6 +23,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import itertools
 import time
+import sys
 
 
 import testcommon
@@ -78,14 +79,20 @@ class TestStrategy(bt.Strategy):
 
     def start(self):
         self.broker.setcommission(commission=2.0, mult=10.0, margin=1000.0)
-        self.tstart = time.clock()
+        if sys.version_info >= (3, 8):
+            self.tstart = time.perf_counter()
+        else:
+            self.tstart = time.clock()
         self.buy_create_idx = itertools.count()
 
     def stop(self):
         global _chkvalues
         global _chkcash
 
-        tused = time.clock() - self.tstart
+        if sys.version_info >= (3, 8):
+            tused = time.perf_counter() - self.tstart
+        else:
+            tused = time.clock() - self.tstart
         if self.p.printdata:
             self.log(('Time used: %s  - Period % d - '
                       'Start value: %.2f - End value: %.2f') %

--- a/tests/test_strategy_unoptimized.py
+++ b/tests/test_strategy_unoptimized.py
@@ -22,6 +22,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import time
+import sys
 
 import testcommon
 
@@ -107,7 +108,10 @@ class TestStrategy(bt.Strategy):
             self.log('Starting portfolio value: %.2f' % self.broker.getvalue(),
                      nodate=True)
 
-        self.tstart = time.clock()
+        if sys.version_info >= (3, 8):
+            self.tstart = time.perf_counter()
+        else:
+            self.tstart = time.clock()
 
         self.buycreate = list()
         self.sellcreate = list()
@@ -115,7 +119,10 @@ class TestStrategy(bt.Strategy):
         self.sellexec = list()
 
     def stop(self):
-        tused = time.clock() - self.tstart
+        if sys.version_info >= (3, 8):
+            tused = time.perf_counter() - self.tstart
+        else:
+            tused = time.clock() - self.tstart
         if self.p.printdata:
             self.log('Time used: %s' % str(tused))
             self.log('Final portfolio value: %.2f' % self.broker.getvalue())


### PR DESCRIPTION
time.clock() was deprecated in py3.3 and removed in py3.8;