### PR TITLE
Fixed backtrader.plot() causing crash in MacOS.

### DIFF
--- a/backtrader/plot/__init__.py
+++ b/backtrader/plot/__init__.py
@@ -27,7 +27,11 @@ except ImportError:
     raise ImportError(
         'Matplotlib seems to be missing. Needed for plotting support')
 else:
-    matplotlib.use('TkAgg')
+    from sys import platform
+    if platform == 'darwin':
+        matplotlib.use('MacOSX')
+    else:
+        matplotlib.use('TkAgg')
 
 
 from .plot import Plot, Plot_OldSync


### PR DESCRIPTION
**Issue:**
Backtrader by default uses TKinter (TkAgg) backend for plotting. But, MacOS does not like TKinter. So when cerebro.plot() is used, it causes a bad crash causing the system to force logout.

**Fix:**
Added platform dependent code. Now on MacOS, it uses MacOS (MacOSX) backend.

**Side Issue(s):**
1. I tried to run the code with cerebro.plot(use='MacOSX'), still the system was crashing. Looks like the "_use_" param in plot() function of backtrader / cerebro is not implemented (correct me if wrong). If that issue can be fixed, it would be much better.
2. Also jupyter lab gives the below error :
    * Tried installing https://github.com/matplotlib/jupyter-matplotlib but no use.
 <img width="382" alt="Screenshot 2020-02-21 at 8 18 17 PM" src="https://user-images.githubusercontent.com/19410501/75044307-695b6f80-54e7-11ea-993a-2852e7c076fc.png">

**References:**
1. https://community.backtrader.com/topic/1597/cerebro-plot-lead-to-system-crash
2. https://community.backtrader.com/topic/393/python-crashes-when-i-try-the-sample-code
3. https://stackoverflow.com/questions/57943180/matplotlib-crashes-in-plt-show-on-macos-with-tkagg-backend 