### PR TITLE
Yahoo data fix

### DIFF
--- a/backtrader/feeds/yahoo.py
+++ b/backtrader/feeds/yahoo.py
@@ -330,7 +330,7 @@ class YahooFinanceData(YahooFinanceCSVData):
                 continue
 
             ctype = resp.headers['Content-Type']
-            if 'text/csv' not in ctype:
+            if ctype not in ['text/csv', 'text/plain']:
                 self.error = 'Wrong content type: %s' % ctype
                 continue  # HTML returned? wrong url?
 


### PR DESCRIPTION
Prevent YahooFinanceData from throwing `No such file or directory:` since Yahoo's response type has changed

For context: https://community.backtrader.com/topic/2363/errno-2-no-such-file-or-directory/7