### PR TITLE
bug fix: #5 fixing writer.py after 1.9.75.123 pull

### DIFF
--- a/backtrader/writer.py
+++ b/backtrader/writer.py
@@ -105,7 +105,7 @@ class WriterFile(WriterBase):
         self.headers = list()
         self.values = list()
 
-    def _start(self):
+    def _start_output(self):
         # open file if needed
         if not hasattr(self, 'out') or not self.out:
             if self.p.out is None:
@@ -119,7 +119,7 @@ class WriterFile(WriterBase):
                 self.close_out = self.p.close_out
 
     def start(self):
-        self._start()
+        self._start_output()
 
         if self.p.csv:
             self.writelineseparator()
@@ -219,8 +219,8 @@ class WriterStringIO(WriterFile):
     def __init__(self):
         super(WriterStringIO, self).__init__()
 
-    def _start(self):
-        super(WriterStringIO, self)._start()
+    def _start_output(self):
+        super(WriterStringIO, self)._start_output()
         self.out = self.out()
 
     def stop(self):

--- a/backtrader/writer.py
+++ b/backtrader/writer.py
@@ -105,7 +105,7 @@ class WriterFile(WriterBase):
         self.headers = list()
         self.values = list()
 
-    def start(self):
+    def _start(self):
         # open file if needed
         if not hasattr(self, 'out') or not self.out:
             if self.p.out is None:
@@ -117,6 +117,9 @@ class WriterFile(WriterBase):
             else:
                 self.out = self.p.out
                 self.close_out = self.p.close_out
+
+    def start(self):
+        self._start()
 
         if self.p.csv:
             self.writelineseparator()
@@ -215,6 +218,9 @@ class WriterStringIO(WriterFile):
 
     def __init__(self):
         super(WriterStringIO, self).__init__()
+
+    def _start(self):
+        super(WriterStringIO, self)._start()
         self.out = self.out()
 
     def stop(self):


### PR DESCRIPTION
There is a regression in test_writer.py test after 1.9.75.123 release/

```
ERROR: test_writer.test_run

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/travis/build/backtrader2/backtrader/tests/test_writer.py", line 48, in test_run
    writer=(bt.WriterStringIO, dict(csv=True)))
  File "/home/travis/build/backtrader2/backtrader/tests/testcommon.py", line 110, in runtest
    cerebro.run()
  File "/home/travis/build/backtrader2/backtrader/backtrader/cerebro.py", line 1085, in run
    wr = wrcls(*wrargs, **wrkwargs)
  File "/home/travis/build/backtrader2/backtrader/backtrader/metabase.py", line 88, in __call__
    _obj, args, kwargs = cls.doinit(_obj, *args, **kwargs)
  File "/home/travis/build/backtrader2/backtrader/backtrader/metabase.py", line 78, in doinit
    _obj.__init__(*args, **kwargs)
  File "/home/travis/build/backtrader2/backtrader/backtrader/writer.py", line 218, in __init__
    self.out = self.out()
AttributeError: 'WriterStringIO' object has no attribute 'out'
```

The problem is with removed initialization of out member in init method of WriterFile. The member is a actually expected to be initialized in init method - see the implementation of the WriterStringIO.

The possible simple fix, is to move the self.out = ... initialization in WriterStringIO.__init__ to WriterStringIO.start method