### PR TITLE
Fix two wrong paramters in two bidask samples

### DIFF
--- a/samples/bidask-to-ohlc/bidask-to-ohlc.py
+++ b/samples/bidask-to-ohlc/bidask-to-ohlc.py
@@ -57,7 +57,7 @@ def runstrat():
         timeframe=bt.TimeFrame.Ticks)
 
     cerebro.resampledata(data,
-                         timeframe=bt.TimeFrame.Ticks,
+                         timeframe=bt.TimeFrame.Minutes,
                          compression=args.compression)
 
     cerebro.addstrategy(St)

--- a/samples/data-bid-ask/bidask.py
+++ b/samples/data-bid-ask/bidask.py
@@ -87,7 +87,9 @@ def runstrategy():
 
     cerebro = bt.Cerebro()  # Create a cerebro
 
-    data = BidAskCSV(dataname=args.data, dtformat=args.dtformat)
+    data = BidAskCSV(dataname=args.data,
+                     dtformat=args.dtformat,
+                     timeframe=bt.TimeFrame.Ticks)
     cerebro.adddata(data)  # Add the 1st data to cerebro
     # Add the strategy to cerebro
     cerebro.addstrategy(St, sma=args.sma, period=args.period)


### PR DESCRIPTION
The two sample files
> samples/data-bid-ask/bidask.py 
samples/bidask-to-ohlc/bidask-to-ohlc.py

are not currently working because of the wrong timeframe setting used. 

This is a simple fix to make them work as expected.