### PR TITLE
use decimals to avoid floating point calculation errors in size

### DIFF
--- a/backtrader/order.py
+++ b/backtrader/order.py
@@ -25,6 +25,7 @@ import collections
 from copy import copy
 import datetime
 import itertools
+from decimal import Decimal
 
 from .utils.py3 import range, with_metaclass, iteritems
 
@@ -60,11 +61,11 @@ class OrderExecutionBit(object):
     '''
 
     def __init__(self,
-                 dt=None, size=0, price=0.0,
-                 closed=0, closedvalue=0.0, closedcomm=0.0,
-                 opened=0, openedvalue=0.0, openedcomm=0.0,
+                 dt=None, size=0.0, price=0.0,
+                 closed=0.0, closedvalue=0.0, closedcomm=0.0,
+                 opened=0.0, openedvalue=0.0, openedcomm=0.0,
                  pnl=0.0,
-                 psize=0, pprice=0.0):
+                 psize=0.0, pprice=0.0):
 
         self.dt = dt
         self.size = size
@@ -127,7 +128,7 @@ class OrderData(object):
     # the len of the exbits can be queried with no concerns about another
     # thread making an append and with no need for a lock
 
-    def __init__(self, dt=None, size=0, price=0.0, pricelimit=0.0, remsize=0,
+    def __init__(self, dt=None, size=0.0, price=0.0, pricelimit=0.0, remsize=0.0,
                  pclose=0.0, trailamount=0.0, trailpercent=0.0):
 
         self.pclose = pclose
@@ -175,10 +176,10 @@ class OrderData(object):
         return self.exbits[key]
 
     def add(self, dt, size, price,
-            closed=0, closedvalue=0.0, closedcomm=0.0,
-            opened=0, openedvalue=0.0, openedcomm=0.0,
+            closed=0.0, closedvalue=0.0, closedcomm=0.0,
+            opened=0.0, openedvalue=0.0, openedcomm=0.0,
             pnl=0.0,
-            psize=0, pprice=0.0):
+            psize=0.0, pprice=0.0):
 
         self.addbit(
             OrderExecutionBit(dt, size, price,
@@ -190,12 +191,12 @@ class OrderData(object):
         # Stores an ExecutionBit and recalculates own values from ExBit
         self.exbits.append(exbit)
 
-        self.remsize -= exbit.size
+        self.remsize = float(Decimal(str(self.remsize)) - Decimal(str(exbit.size)))
 
         self.dt = exbit.dt
         oldvalue = self.size * self.price
         newvalue = exbit.size * exbit.price
-        self.size += exbit.size
+        self.size = float(Decimal(str(self.size)) + Decimal(exbit.size))
         self.price = (oldvalue + newvalue) / self.size
         self.value += exbit.value
         self.comm += exbit.comm

--- a/backtrader/trade.py
+++ b/backtrader/trade.py
@@ -22,6 +22,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import itertools
+from decimal import Decimal
 
 from .utils import AutoOrderedDict
 from .utils.date import num2date
@@ -40,7 +41,7 @@ class TradeHistory(AutoOrderedDict):
         - ``status`` (``int``): Trade status
         - ``dt`` (``float``): float coded datetime
         - ``barlen`` (``int``): number of bars the trade has been active
-        - ``size`` (``int``): current size of the Trade
+        - ``size`` (``float``): current size of the Trade
         - ``price`` (``float``): current price of the Trade
         - ``value`` (``float``): current monetary value of the Trade
         - ``pnl`` (``float``): current profit and loss of the Trade
@@ -108,7 +109,7 @@ class Trade(object):
       - ``status`` (``int``): one of Created, Open, Closed
       - ``tradeid``: grouping tradeid passed to orders during creation
         The default in orders is 0
-      - ``size`` (``int``): current size of the trade
+      - ``size`` (``float``): current size of the trade
       - ``price`` (``float``): current price of the trade
       - ``value`` (``float``): current value of the trade
       - ``commission`` (``float``): current accumulated commission
@@ -163,7 +164,7 @@ class Trade(object):
         )
 
     def __init__(self, data=None, tradeid=0, historyon=False,
-                 size=0, price=0.0, value=0.0, commission=0.0):
+                 size=0.0, price=0.0, value=0.0, commission=0.0):
 
         self.ref = next(self.refbasis)
         self.data = data
@@ -234,7 +235,7 @@ class Trade(object):
         Args:
             order: the order object which has (completely or partially)
                 generated this update
-            size (int): amount to update the order
+            size (float): amount to update the order
                 if size has the same sign as the current trade a
                 position increase will happen
                 if size has the opposite sign as current op size a
@@ -256,7 +257,7 @@ class Trade(object):
 
         # Update size and keep a reference for logic an calculations
         oldsize = self.size
-        self.size += size  # size will carry the opposite sign if reducing
+        self.size = float(Decimal(self.size) + Decimal(size))  # size will carry the opposite sign if reducing
 
         # Check if it has been currently opened
         self.justopened = bool(not oldsize and size)


### PR DESCRIPTION
hi, don't know exactly if this contradicts with concepts of the platform or not, but I hope here is the solution for avoiding floating point errors when fractional position sizes are used (e.g. trading with cryptocurrencies).  Like this:
>>> 0.1 + 0.2
0.30000000000000004

But this can be avoided with decimals:
>>> float(Decimal('0.1') + Decimal('0.2'))
0.3
