### PR TITLE
Fix multiprocessing memory usage issues by instantiating Pool with maxtasksperchild

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -270,6 +270,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
         ('preload', True),
         ('runonce', True),
         ('maxcpus', None),
+        ('maxtasksperchild', None),
         ('stdstats', True),
         ('oldbuysell', False),
         ('oldtrades', False),
@@ -1139,7 +1140,8 @@ class Cerebro(with_metaclass(MetaParams, object)):
                     if self._dopreload:
                         data.preload()
 
-            pool = multiprocessing.Pool(self.p.maxcpus or None)
+            pool = multiprocessing.Pool(self.p.maxcpus or None,
+                                        maxtasksperchild=self.p.maxtasksperchild)
             for r in pool.imap(self, iterstrats):
                 self.runstrats.append(r)
                 for cb in self.optcbs:


### PR DESCRIPTION
When running big optimizations, child processes consume memory until they crash with broken pipe errors. Limiting the number of tasks assigned to each child process forces them to exit and release memory.

See also
https://docs.python.org/3/library/multiprocessing.html?#multiprocessing.pool.Pool
https://stackoverflow.com/a/21613370/3706242