### PR TITLE
Fix ImportError from matplotlib.dates

### DIFF
--- a/backtrader/plot/locator.py
+++ b/backtrader/plot/locator.py
@@ -27,6 +27,7 @@ which can be converted from/to dates
 '''
 
 import datetime
+import warnings
 
 from matplotlib.dates import AutoDateLocator as ADLocator
 from matplotlib.dates import RRuleLocator as RRLocator
@@ -36,7 +37,7 @@ from matplotlib.dates import (HOURS_PER_DAY, MIN_PER_HOUR, SEC_PER_MIN,
                               MONTHS_PER_YEAR, DAYS_PER_WEEK,
                               SEC_PER_HOUR, SEC_PER_DAY,
                               num2date, rrulewrapper, YearLocator,
-                              MicrosecondLocator, warnings)
+                              MicrosecondLocator)
 
 from dateutil.relativedelta import relativedelta
 import numpy as np


### PR DESCRIPTION
matplotlib.dates does not have a module called `warnings`

Reference: https://matplotlib.org/3.1.1/api/dates_api.html