### PR TITLE
Removed the unused parameter compression

### DIFF
--- a/backtrader/analyzers/returns.py
+++ b/backtrader/analyzers/returns.py
@@ -45,14 +45,6 @@ class Returns(TimeFrameAnalyzerBase):
         Pass ``TimeFrame.NoTimeFrame`` to consider the entire dataset with no
         time constraints
 
-      - ``compression`` (default: ``None``)
-
-        Only used for sub-day timeframes to for example work on an hourly
-        timeframe by specifying "TimeFrame.Minutes" and 60 as compression
-
-        If ``None`` then the compression of the 1st data of the system will be
-        used
-
       - ``tann`` (default: ``None``)
 
         Number of periods to use for the annualization (normalization) of the


### PR DESCRIPTION
The `compression` parameter is not used by the class `Returns` at all, therefore it can be safely removed from the doc.