### PR TITLE
Update plot to enable configure figure size

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -988,6 +988,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
             for si, strat in enumerate(stratlist):
                 rfig = plotter.plot(strat, figid=si * 100,
                                     numfigs=numfigs, iplot=iplot,
+                                    width=width, height=height,
                                     start=start, end=end, use=use)
                 # pfillers=pfillers2)
 

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -68,8 +68,8 @@ class PInfo(object):
 
         self.prop = mfontmgr.FontProperties(size=self.sch.subtxtsize)
 
-    def newfig(self, figid, numfig, mpyplot):
-        fig = mpyplot.figure(figid + numfig)
+    def newfig(self, figid, numfig, mpyplot, width, height):
+        fig = mpyplot.figure(figid + numfig, figsize=(width, height))
         self.figs.append(fig)
         self.daxis = collections.OrderedDict()
         self.vaxis = list()
@@ -113,8 +113,8 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
                       zorder=self.pinf.zorder[ax] + 3.0,
                       **kwargs)
 
-    def plot(self, strategy, figid=0, numfigs=1, iplot=True,
-             start=None, end=None, **kwargs):
+    def plot(self, strategy, figid=0, numfigs=1, iplot=True, 
+             width=16, height=9, start=None, end=None, **kwargs):
         # pfillers={}):
         if not strategy.datas:
             return
@@ -164,7 +164,7 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
 
         for numfig in range(numfigs):
             # prepare a figure
-            fig = self.pinf.newfig(figid, numfig, self.mpyplot)
+            fig = self.pinf.newfig(figid, numfig, self.mpyplot, width, height)
             figs.append(fig)
 
             self.pinf.pstart, self.pinf.pend, self.pinf.psize = pranges[numfig]


### PR DESCRIPTION
Update the plot function to enable it to have a confugrable figure size. The cerebro plot function had the params for width and height but were unused.

A lot of users are using the rcparams as the workaround to change the default figure size to make it work. This change will fix that issue.