### PR TITLE
docs: fix simple typo, exexcution -> execution

### DIFF
--- a/backtrader/brokers/bbroker.py
+++ b/backtrader/brokers/bbroker.py
@@ -892,7 +892,7 @@ class BackBroker(bt.BrokerBase):
                 self._execute(order, ago=ago, price=execprice)
                 return
 
-        # If no exexcution has taken place ... annotate the closing price
+        # If no execution has taken place ... annotate the closing price
         order.pannotated = pclose
 
     def _try_exec_limit(self, order, popen, phigh, plow, plimit):


### PR DESCRIPTION
There is a small typo in backtrader/brokers/bbroker.py.

Should read `execution` rather than `exexcution`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md