### PR TITLE
Fix talib line calculation

### DIFF
--- a/backtrader/talib.py
+++ b/backtrader/talib.py
@@ -90,7 +90,7 @@ else:
             return _obj, args, kwargs  # return the object and args
 
     class _TALibIndicator(with_metaclass(_MetaTALibIndicator, bt.Indicator)):
-        CANDLEOVER = 1.02  # 2% over
+        CANDLEOVER = 0.02  # 2% over
         CANDLEREF = 1  # Open, High, Low, Close (0, 1, 2, 3)
 
         @classmethod
@@ -222,8 +222,8 @@ else:
                 self.lines[0][0] = o = out[-1]
 
                 if fsize > lsize:  # candle is present
-                    candleref = narrays[self.CANDLEREF][-1] * self.CANDLEOVER
-                    o2 = candleref * (o / 100.0)
+                    candleref = narrays[self.CANDLEREF][-1]
+                    o2 = candleref * (o / 100.0) * ((o / 100.0) + self.CANDLEOVER)
                     self.lines[1][0] = o2
 
             else:


### PR DESCRIPTION
Without this fix, the bearish value is plotted outside the graph.

Lets say:
candleref = 1.18900
CANDLEOVER = 1.02
o = -100

than is o2 = (1.18900 * 1.02) * (-100 / 100.0) = -1.21278

It should be 2% lower than candleref:
o2 = 1.18900 * (-100 / 100.0) * ((-100 / 100.0) + 0.02) = 1.16522

and of course 2% higher if o = 100:
o2 = 1.18900 * (100 / 100.0) * ((100 / 100.0) + 0.02) = 1.21278

and zero if o = 0:
o2 = 1.18900 * (0/ 100.0) * ((0/ 100.0) + 0.02) = 0