### PR TITLE
Captcha is broken on the community register website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 backtrader
 ==========
-
+ 
 .. image:: https://img.shields.io/pypi/v/backtrader.svg
    :alt: PyPi Version
    :scale: 100%


### PR DESCRIPTION
The captcha on the community website register page is broken and it doesn't let me get past.

Sorry for this PR I couldn't find any email or other way to get in touch.
