### PR TITLE
Changing matplotlib backend selection

### DIFF
--- a/backtrader/plot/__init__.py
+++ b/backtrader/plot/__init__.py
@@ -22,7 +22,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import sys
-
+import os
 
 try:
     import matplotlib
@@ -31,8 +31,16 @@ except ImportError:
         'Matplotlib seems to be missing. Needed for plotting support')
 else:
     touse = 'TKAgg' if sys.platform != 'darwin' else 'MacOSX'
+
+    #In headless mode
+    import os
+    if os.environ.get("DISPLAY") is None and os.environ.get("MPLBACKEND") is None:
+        print('no display found. Using non-interactive Agg backend')
+        touse = "Agg"
+
     try:
-        matplotlib.use(touse)
+        if os.environ.get("MPLBACKEND") is None:
+            matplotlib.use(touse)
     except:
         # if another backend has already been loaded, an exception will be
         # generated and this can be skipped


### PR DESCRIPTION
I am running backtrader in a docker container and noticed plotting would cause an error because I am running in a non-interactive environment. This code just prevents an error from being thrown. I have contemplated adding code that checks if you are in a non-interactive environment then it will just save the figures to file, but I am not sure how well that will be received by the community.