### PR TITLE
fix bug of min() arg is an empty sequence

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -1541,7 +1541,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
                 d.do_qcheck(newqcheck, qlapse.total_seconds())
                 drets.append(d.next(ticks=False))
 
-            d0ret = any((dret for dret in drets))
+            d0ret = any((dret for i,dret in enumerate(drets) if dret and i not in rsonly))
             if not d0ret and any((dret is None for dret in drets)):
                 d0ret = None
 

--- a/backtrader/feeds/__init__.py
+++ b/backtrader/feeds/__init__.py
@@ -52,3 +52,4 @@ from .vchartfile import VChartFile
 
 from .rollover import RollOver
 from .chainer import Chainer
+from .ctpdata import CTPData

--- a/backtrader/feeds/ctpdata.py
+++ b/backtrader/feeds/ctpdata.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2015-2020 Daniel Rodriguez
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import datetime
+
+import backtrader as bt
+from backtrader.feed import DataBase
+from backtrader import TimeFrame, date2num, num2date
+from backtrader.utils.py3 import (integer_types, queue, string_types,
+                                  with_metaclass)
+from backtrader.metabase import MetaParams
+from backtrader.stores import ctpstore
+
+
+class MetaCTPData(DataBase.__class__):
+    def __init__(cls, name, bases, dct):
+        '''Class has already been created ... register'''
+        # Initialize the class
+        super(MetaCTPData, cls).__init__(name, bases, dct)
+
+        # Register with the store
+        ctpstore.CTPStore.DataCls = cls
+
+
+class CTPData(with_metaclass(MetaCTPData, DataBase)):
+    '''Interactive Brokers Data Feed.
+
+    Supports the following contract specifications in parameter ``dataname``:
+
+          - TICKER  # Stock type and SMART exchange
+          - TICKER-STK  # Stock and SMART exchange
+          - TICKER-STK-EXCHANGE  # Stock
+          - TICKER-STK-EXCHANGE-CURRENCY  # Stock
+
+          - TICKER-CFD  # CFD and SMART exchange
+          - TICKER-CFD-EXCHANGE  # CFD
+          - TICKER-CDF-EXCHANGE-CURRENCY  # Stock
+
+          - TICKER-IND-EXCHANGE  # Index
+          - TICKER-IND-EXCHANGE-CURRENCY  # Index
+
+          - TICKER-YYYYMM-EXCHANGE  # Future
+          - TICKER-YYYYMM-EXCHANGE-CURRENCY  # Future
+          - TICKER-YYYYMM-EXCHANGE-CURRENCY-MULT  # Future
+          - TICKER-FUT-EXCHANGE-CURRENCY-YYYYMM-MULT # Future
+
+          - TICKER-YYYYMM-EXCHANGE-CURRENCY-STRIKE-RIGHT  # FOP
+          - TICKER-YYYYMM-EXCHANGE-CURRENCY-STRIKE-RIGHT-MULT  # FOP
+          - TICKER-FOP-EXCHANGE-CURRENCY-YYYYMM-STRIKE-RIGHT # FOP
+          - TICKER-FOP-EXCHANGE-CURRENCY-YYYYMM-STRIKE-RIGHT-MULT # FOP
+
+          - CUR1.CUR2-CASH-IDEALPRO  # Forex
+
+          - TICKER-YYYYMMDD-EXCHANGE-CURRENCY-STRIKE-RIGHT  # OPT
+          - TICKER-YYYYMMDD-EXCHANGE-CURRENCY-STRIKE-RIGHT-MULT  # OPT
+          - TICKER-OPT-EXCHANGE-CURRENCY-YYYYMMDD-STRIKE-RIGHT # OPT
+          - TICKER-OPT-EXCHANGE-CURRENCY-YYYYMMDD-STRIKE-RIGHT-MULT # OPT
+
+    Params:
+
+      - ``qcheck`` (default: ``0.5``)
+
+        Time in seconds to wake up if no data is received to give a chance to
+        resample/replay packets properly and pass notifications up the chain
+
+      - ``backfill_start`` (default: ``True``)
+
+        Perform backfilling at the start. The maximum possible historical data
+        will be fetched in a single request.
+
+      - ``backfill`` (default: ``True``)
+
+        Perform backfilling after a disconnection/reconnection cycle. The gap
+        duration will be used to download the smallest possible amount of data
+
+      - ``backfill_from`` (default: ``None``)
+
+        An additional data source can be passed to do an initial layer of
+        backfilling. Once the data source is depleted and if requested,
+        backfilling from IB will take place. This is ideally meant to backfill
+        from already stored sources like a file on disk, but not limited to.
+
+      - ``latethrough`` (default: ``False``)
+
+        If the data source is resampled/replayed, some ticks may come in too
+        late for the already delivered resampled/replayed bar. If this is
+        ``True`` those ticks will bet let through in any case.
+
+        Check the Resampler documentation to see who to take those ticks into
+        account.
+
+        This can happen especially if ``timeoffset`` is set to ``False``  in
+        the ``IBStore`` instance and the TWS server time is not in sync with
+        that of the local computer
+
+      - ``tradename`` (default: ``None``)
+        Useful for some specific cases like ``CFD`` in which prices are offered
+        by one asset and trading happens in a different onel
+    '''
+    params = (
+        ('qcheck', 0.5),  # timeout in seconds (float) to check for events
+        ('backfill', True),  # do backfilling when reconnecting
+        ('backfill_from', None),  # additional data source to do backfill from
+        ('latethrough', False),  # let late samples through
+        ('tradename', None),  # use a different asset as order target
+    )
+
+    _store = ctpstore.CTPStore
+
+    # States for the Finite State Machine in _load
+    _ST_FROM, _ST_START, _ST_LIVE, _ST_HISTORBACK, _ST_OVER = range(5)
+
+    def _timeoffset(self):
+        return self.ctp.timeoffset()
+
+    def islive(self):
+        '''Returns ``True`` to notify ``Cerebro`` that preloading and runonce
+        should be deactivated'''
+        return True
+
+    def __init__(self, **kwargs):
+        self.ctp = self._store(**kwargs)
+        self.contract = self.p.dataname
+        self.tradecontract = self.p.tradename
+        self.lastvolume = 0
+
+    def setenvironment(self, env):
+        '''Receives an environment (cerebro) and passes it over to the store it
+        belongs to'''
+        super(CTPData, self).setenvironment(env)
+        env.addstore(self.ctp)
+
+    def start(self):
+        '''Starts the IB connecction and gets the real contract and
+        contractdetails if it exists'''
+        super(CTPData, self).start()
+        # Kickstart store and get queue to wait on
+        self.ctp.start(data=self)
+        self.qlive = self.ctp.getQueue(self.contract)
+
+        if self.p.backfill_from is not None:
+            self._state = self._ST_FROM
+            self.p.backfill_from.setenvironment(self._env)
+            self.p.backfill_from._start()
+        else:
+            self._state = self._ST_START  # initial state for _load
+        self._storedmsg = dict()  # keep pending live message (under None)
+
+        if not self.ctp.connected():
+            return
+
+        self.put_notification(self.CONNECTED)
+
+        if self._state == self._ST_START:
+            self._start_finish()  # to finish initialization
+            self._st_start()
+
+    def stop(self):
+        '''Stops and tells the store to stop'''
+        super(CTPData, self).stop()
+        self.canceldata()
+        self.ctp.stop()
+
+    def reqdata(self):
+        '''request real-time data. checks cash vs non-cash) and param useRT'''
+        if self.contract:
+            self.qlive = self.ctp.reqMktData(self.contract)
+            return self.qlive
+
+    def canceldata(self):
+        '''Cancels Market Data subscription, checking asset type and rtbar'''
+        if self.contract:
+            self.ctp.cancelMktData(self.qlive)
+
+    def haslivedata(self):
+        return bool(self._storedmsg or self.qlive.qsize())
+
+    def _load(self):
+        if self.contract is None or self._state == self._ST_OVER:
+            return False  # nothing can be done
+
+        while True:
+            if self._state == self._ST_LIVE:
+                try:
+                    msg = (self._storedmsg.pop(None, None) or
+                           self.qlive.get(timeout=self._qcheck))
+                except queue.Empty:
+                    return None
+
+                if msg is None:  # Conn broken during historical/backfilling
+                    self.put_notification(self.CONNBROKEN)
+                    # Try to reconnect
+                    if not self.ctp.reconnect(resub=True):
+                        self.put_notification(self.DISCONNECTED)
+                        return False  # failed
+                    continue
+
+                elif isinstance(msg, integer_types):
+                    # Unexpected notification for historical data skip it
+                    # May be a "not connected not yet processed"
+                    self.put_notification(self.UNKNOWN, msg)
+                    continue
+                
+                if self._laststatus != self.LIVE:
+                    if self.qlive.qsize() <= 1:  # very short live queue
+                        self.put_notification(self.LIVE)
+                
+                ret = self._load_rtvolume(msg)
+                if ret:
+                    return True
+                # could not load bar ... go and get new one
+                continue
+
+            elif self._state == self._ST_FROM:
+                if not self.p.backfill_from.next():
+                    # additional data source is consumed
+                    self._state = self._ST_START
+                    continue
+
+                # copy lines of the same name
+                for alias in self.lines.getlinealiases():
+                    lsrc = getattr(self.p.backfill_from.lines, alias)
+                    ldst = getattr(self.lines, alias)
+
+                    ldst[0] = lsrc[0]
+
+                return True
+
+            elif self._state == self._ST_START:
+                if not self._st_start():
+                    return False
+
+    def _st_start(self):
+        # Live is requested
+        if not self.ctp.reconnect(resub=True):
+            self.put_notification(self.DISCONNECTED)
+            self._state = self._ST_OVER
+            return False  # failed - was so
+
+        self._state = self._ST_LIVE
+        return True  # no return before - implicit continue
+
+
+    def _load_rtvolume(self, rtvol):
+        # A single tick is delivered and is therefore used for the entire set
+        # of prices. Ideally the
+        # contains open/high/low/close/volume prices
+        # Datetime transformation
+        dt = date2num(rtvol.datetime)
+        if dt < self.lines.datetime[-1] and not self.p.latethrough:
+            return False  # cannot deliver earlier than already delivered
+
+        self.lines.datetime[0] = dt
+
+        # Put the tick into the bar
+        tick = rtvol.price
+        self.lines.open[0] = tick
+        self.lines.high[0] = tick
+        self.lines.low[0] = tick
+        self.lines.close[0] = tick
+        self.lines.openinterest[0] = rtvol.openinterest
+        self.lines.volume[0] = rtvol.volume - self.lastvolume
+        self.lastvolume = rtvol.volume
+
+        return True

--- a/backtrader/feeds/whdata.py
+++ b/backtrader/feeds/whdata.py
@@ -1,0 +1,73 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import datetime
+import struct
+
+from backtrader import feed,date2num
+
+
+class WHData(feed.DataBase):
+    '''
+    Support for `文华财经`_ binary on-disk files for
+    both daily and intradaily formats.
+
+    Note:
+
+      - ``dataname``: to file or open file-like object
+
+        If a file-like object is passed, the ``timeframe`` parameter will be
+        used to determine which is the actual timeframe.
+
+        Else the file extension (``.fd`` for daily and ``.min`` for intraday)
+        will be used.
+    '''
+
+    def start(self):
+        super(WHData, self).start()
+
+        self.barsize = 4*9
+        self.barfmt = '<I8f'
+
+        self.f = None
+        if hasattr(self.p.dataname, 'read'):
+            # A file has been passed in (ex: from a GUI)
+            self.f = self.p.dataname
+        else:
+            self.f = open(self.p.dataname, 'rb')
+        
+        bts = self.f.read(4)
+        self.count = int.from_bytes(bts, byteorder='little')
+
+
+    def stop(self):
+        if self.f is not None:
+            self.f.close()
+            self.f = None
+
+
+    def _load(self):
+        if self.f is None:
+            return False
+
+        # Let an exception propagate to let the caller know
+        bardata = self.f.read(self.barsize)
+        if not bardata:
+            return False
+
+        # ('timestamp','open','close','high','low','volume','openinterest','settlement','rate')
+        bdata = struct.unpack(self.barfmt, bardata)
+
+        dt = datetime.datetime.fromtimestamp(bdata[0])
+
+        self.lines.datetime[0] = date2num(dt)
+
+        self.lines.open[0] = bdata[1]
+        self.lines.high[0] = bdata[3]
+        self.lines.low[0] = bdata[4]
+        self.lines.close[0] = bdata[2]
+        self.lines.volume[0] = bdata[5]
+        self.lines.openinterest[0] = bdata[6]
+
+        return True
+

--- a/backtrader/stores/ctpstore.py
+++ b/backtrader/stores/ctpstore.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2015-2020 Daniel Rodriguez
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import collections
+from copy import copy
+from datetime import date, datetime, timedelta
+import inspect
+import itertools
+import random
+import threading
+import time
+import logging
+_logger = logging.getLogger()
+
+from ctp import MdApi,TraderApi,FunBroker
+from ctp import error as ctperror
+
+from backtrader import TimeFrame, Position
+from backtrader.store import Store
+from backtrader.utils.py3 import bytes, bstr, queue, with_metaclass, long
+from backtrader.utils import AutoDict, UTC
+
+
+class RTVolume(object):
+
+    def __init__(self, field):
+        dt = field['ActionDay'] # 'ActionDay': '20210205'
+        tm = field['UpdateTime'] # 'UpdateTime': '22:04:48'
+        ms = field['UpdateMillisec'] # 'UpdateMillisec': 500
+        self.datetime = datetime.strptime(f'{dt} {tm}.{ms}','%Y%m%d %H:%M:%S.%f')
+        self.price = field['LastPrice'] # 'LastPrice': 4276.0
+        self.volume = field['Volume'] # 'Volume': 796510
+        self.openinterest = field['OpenInterest']  # 'OpenInterest': 18510.0
+
+
+class LogBroker(FunBroker):
+    '''derived only for logging, use base class directly is ok'''
+    def errcheck(self, result, func, arguments):
+        _logger.info(f'{self.funname}{self.origargs} {arguments} -> {result}')
+        return super().errcheck(result, func, arguments)
+
+
+class Md(MdApi):
+    '''derived only for logging, use base class directly is ok'''
+    def call_back(self,fun,p,rsp,res,last,ext):
+        #print(f'{fun}({p},{rsp},{res},{last},{ext})')
+        newargs = super().call_back(fun,p,rsp,res,last,ext)
+        if fun != b'OnRtnDepthMarketData':
+            fun = fun.decode()
+            _logger.info(f'md:{fun}{newargs}')
+        return newargs
+
+
+class Td(TraderApi):
+    '''derived only for logging, use base class directly is ok'''
+    def call_back(self,fun,p,rsp,res,last,ext):
+        #print(f'{fun}({p},{rsp},{res},{last},{ext})')
+        newargs = super().call_back(fun,p,rsp,res,last,ext)
+        fun = fun.decode()
+        _logger.info(f'td:{fun}{newargs}')
+        return newargs
+
+
+# Decorator to mark methods to register with ctp
+def ctpregister(f):
+    f._ctpregister = True
+    return f
+
+
+class CTPStore(Store):
+    '''Singleton class wrapping an ibpy ibConnection instance.
+
+    The parameters can also be specified in the classes which use this store,
+    like ``IBData`` and ``IBBroker``
+
+    Params:
+
+      - ``host`` (default:``127.0.0.1``): where IB TWS or IB Gateway are
+        actually running. And although this will usually be the localhost, it
+        must not be
+
+      - ``port`` (default: ``7496``): port to connect to. The demo system uses
+        ``7497``
+
+      - ``clientId`` (default: ``None``): which clientId to use to connect to
+        TWS.
+
+        ``None``: generates a random id between 1 and 65535
+        An ``integer``: will be passed as the value to use.
+
+      - ``notifyall`` (default: ``False``)
+
+        If ``False`` only ``error`` messages will be sent to the
+        ``notify_store`` methods of ``Cerebro`` and ``Strategy``.
+
+        If ``True``, each and every message received from TWS will be notified
+
+      - ``_debug`` (default: ``False``)
+
+        Print all messages received from TWS to standard output
+
+      - ``reconnect`` (default: ``3``)
+
+        Number of attempts to try to reconnect after the 1st connection attempt
+        fails
+
+        Set it to a ``-1`` value to keep on reconnecting forever
+
+      - ``timeout`` (default: ``3.0``)
+
+        Time in seconds between reconnection attemps
+
+      - ``timeoffset`` (default: ``True``)
+
+        If True, the time obtained from ``reqCurrentTime`` (IB Server time)
+        will be used to calculate the offset to localtime and this offset will
+        be used for the price notifications (tickPrice events, for example for
+        CASH markets) to modify the locally calculated timestamp.
+
+        The time offset will propagate to other parts of the ``backtrader``
+        ecosystem like the **resampling** to align resampling timestamps using
+        the calculated offset.
+
+      - ``timerefresh`` (default: ``60.0``)
+
+        Time in seconds: how often the time offset has to be refreshed
+
+      - ``indcash`` (default: ``True``)
+
+        Manage IND codes as if they were cash for price retrieval
+    '''
+
+    # Set a base for the data requests (historical/realtime) to distinguish the
+    # id in the error notifications from orders, where the basis (usually
+    # starting at 1) is set by TWS
+    REQIDBASE = 0x01000000
+
+    params = (
+        ('mdfront', 'tcp://180.168.146.187:10110'),
+        ('tdfront', 'tcp://180.168.146.187:10101'),
+        ('brokerid', '9999'),
+        ('username', '010631'),
+        ('password', '123456'),
+        ('notifyall', False),
+        ('_debug', False),
+        ('timeout', 10.0),  # timeout between reconnections
+        ('timeoffset', True),  # Use offset to server for timestamps if needed
+        ('timerefresh', 60.0),  # How often to refresh the timeoffset
+    )
+
+    def __init__(self):
+        super(CTPStore, self).__init__()
+
+        self._lock_q = threading.Lock()  # sync access to _tickerId/Queues
+        self._lock_accupd = threading.Lock()  # sync account updates
+        self._lock_pos = threading.Lock()  # sync account updates
+        self._lock_notif = threading.Lock()  # sync access to notif queue
+
+        # Account list received
+        self._event_managed_accounts = threading.Event()
+        self._event_accdownload = threading.Event()
+
+        self.dontreconnect = False  # for non-recoverable connect errors
+
+        self._env = None  # reference to cerebro for general notifications
+        self.broker = None  # broker instance
+        self.datas = list()  # datas that have registered over start
+        self.ccount = 0  # requests to start (from cerebro or datas)
+
+        self._lock_tmoffset = threading.Lock()
+        self.tmoffset = timedelta()  # to control time difference with server
+
+        # Structures to hold datas requests
+        self.qs = collections.OrderedDict()  # key: tickerId -> queues
+        self.ts = collections.OrderedDict()  # key: queue -> tickerId
+        self.iscash = dict()  # tickerIds from cash products (for ex: EUR.JPY)
+
+        self.histexreq = dict()  # holds segmented historical requests
+        self.histfmt = dict()  # holds datetimeformat for request
+        self.histsend = dict()  # holds sessionend (data time) for request
+        self.histtz = dict()  # holds sessionend (data time) for request
+
+        self.acc_cash = AutoDict()  # current total cash per account
+        self.acc_value = AutoDict()  # current total value per account
+        self.acc_upds = AutoDict()  # current account valueinfos per account
+
+        self.port_update = False  # indicate whether to signal to broker
+
+        self.positions = collections.defaultdict(Position)  # actual positions
+
+        self._tickerId = itertools.count(self.REQIDBASE)  # unique tickerIds
+        self.orderid = None  # next possible orderid (will be itertools.count)
+
+        self.cdetails = collections.defaultdict(list)  # hold cdetails requests
+
+        self.managed_accounts = list()  # received via managedAccounts
+
+        self.notifs = queue.Queue()  # store notifications for cerebro
+
+        self.reqid = itertools.count(1)
+        self.mdconnectevent = threading.Event()
+        self.tdconnectevent = threading.Event()
+        self.mdloginevent = threading.Event()
+        self.tdloginevent = threading.Event()
+        self.mdlogined = False  # user login state
+        self.tdlogined = False
+        self.mderrcode = ctperror.NONE
+        self.tderrcode = ctperror.NONE
+        self.md = Md(broker=LogBroker)  # create md instance
+        self.td = Td(broker=LogBroker)
+        # Register decorated methods in md instance
+        methods = inspect.getmembers(self, inspect.ismethod)
+        for name, method in methods:
+            if getattr(method, '_ctpregister', False):
+                segs = name.split('_')
+                api = getattr(self, segs[0], None)
+                if api:
+                    setattr(api,segs[-1],method)
+
+        self.md.RegisterFront(self.p.mdfront)  # registe ctp md front
+        self.td.RegisterFront(self.p.tdfront)
+        self.md.Init()  # init ctp
+        self.td.Init()
+
+
+    def start(self, data=None, broker=None):
+        super(CTPStore, self).start(data,broker)
+        self.reconnect(fromstart=True)  # reconnect should be an invariant
+
+    def stop(self):
+        super(CTPStore, self).stop()
+
+    def logmsg(self, *args):
+        # for logging purposes
+        if self.p._debug:
+            _logger.info(*args)
+
+
+    def connected(self):
+        return self.mdlogined and self.tdlogined  # non-connected (including non-initialized)
+
+
+    def reconnect(self, fromstart=False, resub=False):
+
+        if self.connected():
+            if resub:
+                self.startdatas()
+            return True  # nothing to do
+
+        while not self.connected():
+            if not (self.mdconnectevent.wait(timeout=self.p.timeout) and self.tdconnectevent.wait(timeout=self.p.timeout)):
+                return False
+            if not self.mdlogined:
+                self.mdloginevent.clear()
+                self.mderrcode = ctperror.NONE
+                self.md.ReqUserLogin(dict(BrokerID=self.p.brokerid,UserID=self.p.username,Password=self.p.password),next(self.reqid))
+            if not self.tdlogined:
+                self.tdloginevent.clear()
+                self.tderrcode = ctperror.NONE
+                self.td.ReqUserLogin(dict(BrokerID=self.p.brokerid,UserID=self.p.username,Password=self.p.password),next(self.reqid))
+
+            if not self.mdlogined:
+                self.mdloginevent.wait(timeout=self.p.timeout)
+                if self.mderrcode in (ctperror.INVALID_LOGIN,):
+                    return False
+            if not self.tdlogined:
+                self.tdloginevent.wait(timeout=self.p.timeout)
+                if self.tderrcode in (ctperror.INVALID_LOGIN,):
+                    return False
+
+        if self.connected():
+            if not fromstart or resub:
+                self.startdatas()
+            return True
+        return False
+
+
+    def startdatas(self):
+        # kickstrat datas, not returning until all of them have been done
+        for data in self.datas:
+            data.reqdata()
+
+
+    def stopdatas(self):
+        # stop subs and force datas out of the loop (in LIFO order)
+        for data in self.datas:
+            data.canceldata()
+
+    
+    @ctpregister
+    def md_OnFrontConnected(self):
+        self.mdconnectevent.set()
+
+    @ctpregister
+    def td_OnFrontConnected(self):
+        self.tdconnectevent.set()
+
+
+    @ctpregister
+    def md_OnFrontDisconnected(self, reason):
+        # when disconnected, the low api will auto reconncet
+        connected = self.connected()
+        self.mdlogined = False
+        self.mdconnectevent.clear()
+        self.mdloginevent.set() # in case of logining and disconnect
+        # notify datas disconnected
+        if connected:
+            with self._lock_q:
+                for q in self.ts:
+                    q.put(None)
+    
+
+    @ctpregister
+    def td_OnFrontDisconnected(self, reason):
+        # when disconnected, the low api will auto reconncet
+        connected = self.connected()
+        self.tdlogined = False
+        self.tdconnectevent.clear()
+        self.tdloginevent.set() # in case of logining and disconnect
+        # notify datas disconnected
+        if connected:
+            with self._lock_q:
+                for q in self.ts:
+                    q.put(None)
+
+
+    @ctpregister
+    def md_OnRspUserLogin(self, field, info, reqid, islast):
+        # md:OnRspUserLogin[{'TradingDay': '20210113', 'LoginTime': '', 'BrokerID': '', 'UserID': '', 'SystemName': '', 'FrontID': 0, 'SessionID': 0, 'MaxOrderRef': '', 'SHFETime': '', 'DCETime': '', 'CZCETime': '', 'FFEXTime': '', 'INETime': ''}, {'ErrorID': 0, 'ErrorMsg': 'CTP:No Error'}, 0, True]
+        errcode = info['ErrorID']
+        if errcode == ctperror.NONE:
+            self.mdlogined = True
+        self.mderrcode = errcode
+        self.logmsg(f'user {self.p.username} mdlogin {info}')
+        self.mdloginevent.set() #succeed or fail
+
+
+    @ctpregister
+    def td_OnRspUserLogin(self, field, info, reqid, islast):
+        # 
+        errcode = info['ErrorID']
+        if errcode == ctperror.NONE:
+            self.tdlogined = True
+        self.tderrcode = errcode
+        self.logmsg(f'user {self.p.username} tdlogin {info}')
+        self.tdloginevent.set() #succeed or fail
+
+
+    @ctpregister
+    def md_OnRspUserLogout(self, field, info, reqid, islast):
+        pass
+
+    @ctpregister
+    def md_OnRspSubMarketData(self, field, info, reqid, islast):
+        # the info['ErrorID'] always ctperror.NONE,even if sub InstrumentID not exist
+        pass
+
+    @ctpregister
+    def md_OnRspUnSubMarketData(self, field, info, reqid, islast):
+        # the info['ErrorID'] always ctperror.NONE,even if sub InstrumentID not exist
+        pass
+
+
+    @ctpregister
+    def md_OnRtnDepthMarketData(self, field):
+        # {'TradingDay': '20210205', 'InstrumentID': 'rb2105', 'ExchangeID': '', 'ExchangeInstID': '', 
+        # 'LastPrice': 4275.0, 'PreSettlementPrice': 4216.0, 'PreClosePrice': 4246.0, 
+        # 'PreOpenInterest': 1174941.0, 'OpenPrice': 4243.0, 'HighestPrice': 4279.0, 'LowestPrice': 4226.0, 
+        # 'Volume': 796475, 'Turnover': 33813341680.0, 'OpenInterest': 1154243.0, 'ClosePrice': 1.7976931348623157e+308, 
+        # 'SettlementPrice': 1.7976931348623157e+308, 'UpperLimitPrice': 4426.0, 'LowerLimitPrice': 4005.0, 
+        # 'PreDelta': 0.0, 'CurrDelta': 1.7976931348623157e+308, 'UpdateTime': '10:56:23', 'UpdateMillisec': 0, 
+        # 'BidPrice1': 4275.0, 'BidVolume1': 94, 'AskPrice1': 4276.0, 'AskVolume1': 642, 'BidPrice2': 1.7976931348623157e+308, 
+        # 'BidVolume2': 0, 'AskPrice2': 1.7976931348623157e+308, 'AskVolume2': 0, 'BidPrice3': 1.7976931348623157e+308, 
+        # 'BidVolume3': 0, 'AskPrice3': 1.7976931348623157e+308, 'AskVolume3': 0, 'BidPrice4': 1.7976931348623157e+308, 
+        # 'BidVolume4': 0, 'AskPrice4': 1.7976931348623157e+308, 'AskVolume4': 0, 'BidPrice5': 1.7976931348623157e+308, 
+        # 'BidVolume5': 0, 'AskPrice5': 1.7976931348623157e+308, 'AskVolume5': 0, 'AveragePrice': 42453.738886970714, 
+        # 'ActionDay': '20210205'}
+        contract = field['InstrumentID']
+        self.qs[contract].put(RTVolume(field))
+
+
+    @ctpregister
+    def md_OnRspError(self, info, reqid, islast):
+        self.logmsg(f'md:OnRspError:{info} {reqid} {islast}')
+        errcode = info['ErrorID']
+        self.mderrcode = errcode
+        with self._lock_q:
+            for q in self.ts:
+                q.put(errcode)
+    
+    @ctpregister
+    def td_OnRspError(self, info, reqid, islast):
+        self.logmsg(f'td:OnRspError:{info} {reqid} {islast}')
+        errcode = info['ErrorID']
+        self.tderrcode = errcode
+        with self._lock_q:
+            for q in self.ts:
+                q.put(errcode)
+
+
+    def timeoffset(self):
+        with self._lock_tmoffset:
+            return self.tmoffset
+
+    def getQueue(self, contract=None):
+        '''Creates ticker/Queue for data delivery to a data feed'''
+        with self._lock_q:
+            if contract in self.qs:
+                return self.qs[contract]
+            else:
+                q = queue.Queue()
+                if contract:
+                    self.qs[contract] = q  # can be managed from other thread
+                    self.ts[q] = contract
+                else:
+                    q.put(None)
+                return q
+
+    def cancelQueue(self, q, sendnone=False):
+        '''Cancels a Queue for data delivery'''
+        # pop ts (tickers) and with the result qs (queues)
+        with self._lock_q:
+            contract = self.ts.pop(q, None)
+            self.qs.pop(contract, None)
+        if sendnone:
+            q.put(None)
+
+    def validQueue(self, q):
+        '''Returns (bool)  if a queue is still valid'''
+        return q in self.ts  # queue -> ticker
+
+
+    def reqMktData(self, contract):
+        '''Creates a MarketData subscription
+
+        Params:
+          - contract: a ib.ext.Contract.Contract intance
+
+        Returns:
+          - a Queue the client can wait on to receive a RTVolume instance
+        '''
+        # get a ticker/queue for identification/data delivery
+        q = self.getQueue(contract)
+        if self.connected():
+            self.md.SubscribeMarketData([contract])
+        return q
+
+    def cancelMktData(self, q):
+        '''Cancels an existing MarketData subscription
+
+        Params:
+          - q: the Queue returned by reqMktData
+        '''
+        with self._lock_q:
+            contract = self.ts.get(q, None)
+        if contract and self.connected():
+            self.md.UnSubscribeMarketData([contract])
+        self.cancelQueue(q, True)
+


### PR DESCRIPTION
not sure the change is ok or not but there is a bug:

[ERROR|03/03 07:01:05.141]: min() arg is an empty sequence
Traceback (most recent call last):
  File "btctp.py", line 86, in <module>
    runstrat()
  File "btctp.py", line 61, in runstrat
    cerebro.run()
  File "C:\Program Files\Python37\lib\site-packages\backtrader\cerebro.py", line 1127, in run
    runstrat = self.runstrategies(iterstrat)
  File "C:\Program Files\Python37\lib\site-packages\backtrader\cerebro.py", line 1298, in runstrategies
    self._runnext(runstrats)
  File "C:\Program Files\Python37\lib\site-packages\backtrader\cerebro.py", line 1557, in _runnext
    dt0 = min((d for i, d in enumerate(dts)
ValueError: min() arg is an empty sequence

in line 1557
dt0 = min((d for i, d in enumerate(dts)
                               if d is not None and i not in rsonly))
min() arg may be an empty sequence

use like this:
def runstrat(user,password):
    cerebro = bt.Cerebro()
    store = ctpstore.CTPStore(mdfront=mdfront,tdfront=tdfront,username=user,password=password,timeoffset=False,timeout=None)
    CTPDataFactory = store.getdata
    data0 = CTPDataFactory(dataname='rb2105',qcheck=3)
    data1 = CTPDataFactory(dataname='ZC105',qcheck=3)
    cerebro.addstrategy(TestStrategy)
    cerebro.adddata(data0,name='RB2105')
    cerebro.adddata(data1,name='ZC105')
    cerebro.resampledata(data0,name='rb1min',timeframe=bt.TimeFrame.Minutes)
    cerebro.run()
