### PR TITLE
Some bug fixes that IB users commonly face

### DIFF
--- a/backtrader/feed.py
+++ b/backtrader/feed.py
@@ -423,6 +423,7 @@ class AbstractDataBase(with_metaclass(MetaAbstractDataBase,
             if self.lines.datetime[0] > datamaster.lines.datetime[0]:
                 # can't deliver new bar, too early, go back
                 self.rewind()
+                return False
             else:
                 if ticks:
                     self._tick_fill()

--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -1187,7 +1187,8 @@ class IBStore(with_metaclass(MetaSingleton, object)):
         if dim == 'M':
             month = dt.month - 1 + size  # -1 to make it 0 based, readd below
             years, month = divmod(month, 12)
-            return dt.replace(year=dt.year + years, month=month + 1)
+            # return dt.replace(year=dt.year + years, month=month + 1)
+            return dt.replace(year=dt.year + years, month=month + 1, day=1) + timedelta(dt.day - 1)
 
         if dim == 'Y':
             return dt.replace(year=dt.year + size)


### PR DESCRIPTION
1.  Added `return False` to line no. 426 in _backtrader\feed.py_
    - to avoid `ERROR: __len__() should return >= 0 on liveFeed`
    - reference : [issue adressed here](https://community.backtrader.com/topic/1367/error-__len__-should-return-0-on-livefeed)


2.  Replace line no. 1190 in _backtrader\stores\ibstore.py_
    - to avoid `ValueError: day is out of range for month`
    -   PREV ->  `# return dt.replace(year=dt.year + years, month=month + 1)`
        NEW  ->  `return dt.replace(year=dt.year + years, month=month + 1, day=1) + timedelta(dt.day - 1)`