### PR TITLE
fix pandas TypeError when using calendar

### DIFF
--- a/backtrader/tradingcal.py
+++ b/backtrader/tradingcal.py
@@ -265,7 +265,7 @@ class PandasMarketCalendar(TradingCalendarBase):
         The return value is a tuple with 2 components: opentime, closetime
         '''
         while True:
-            i = self.idcache.index.searchsorted(day.date())
+            i = self.idcache.index.searchsorted(day.replace(hour=0, minute=0, second=0, microsecond=0))
             if i == len(self.idcache):
                 # keep a cache of 1 year to speed up searching
                 self.idcache = self._calendar.schedule(day, day + self.csize)


### PR DESCRIPTION
Pandas==1.2.4 raise "TypeError: value should be a 'Timestamp', 'NaT', or array of those. Got 'date' instead." Need datetime type instead of date type here.