### PR TITLE
Add get_value alias in ibbroker

### DIFF
--- a/backtrader/brokers/ibbroker.py
+++ b/backtrader/brokers/ibbroker.py
@@ -302,6 +302,8 @@ class IBBroker(with_metaclass(MetaIBBroker, BrokerBase)):
         self.value = self.ib.get_acc_value()
         return self.value
 
+    get_value = getvalue
+    
     def getposition(self, data, clone=True):
         return self.ib.getposition(data.tradecontract, clone=clone)
 


### PR DESCRIPTION
Added a `get_value` alias in `IBBroker`. 

Currently, `IBBroker` only has a `getvalue` function. Without this fix, the line `pvals = [self.strategy.broker.get_value([d]) for d in self.datas]` in `PositionsValue` analyzer raises an exception when `IBBroker` is used. 