### PR TITLE
Yahoo 404 - Changed the request User-Agent to accepted value

### DIFF
--- a/backtrader/feeds/yahoo.py
+++ b/backtrader/feeds/yahoo.py
@@ -268,6 +268,7 @@ class YahooFinanceData(YahooFinanceCSVData):
 
         crumb = None
         sess = requests.Session()
+        sess.headers['User-Agent'] = 'backtrader'
         for i in range(self.p.retries + 1):  # at least once
             resp = sess.get(url, **sesskwargs)
             if resp.status_code != requests.codes.ok:


### PR DESCRIPTION
Without this change the simple basic tutorials are not executable because yahoo blocks the default user agent from the requests lib