### PR TITLE
Apple M1 processors / RuntimeError in backtrader/cerebro.py line 1142 multiprocessing.Pool

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -1139,7 +1139,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
                     if self._dopreload:
                         data.preload()
 
-            pool = multiprocessing.Pool(self.p.maxcpus or None)
+            pool = multiprocessing.get_context("fork").Pool(self.p.maxcpus or None)
             for r in pool.imap(self, iterstrats):
                 self.runstrats.append(r)
                 for cb in self.optcbs:


### PR DESCRIPTION
If backtrader is running on Apple M1 processor, the following error occurs in the multiprocessing part of cerebro.py:
```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```

The solution is described in: https://stackoverflow.com/questions/67999589/multiprocessing-with-pool-throws-error-on-m1-macbook