### PR TITLE
decrease the precision of 'sessionend' according the rounding error of date2num and num2date

### DIFF
--- a/backtrader/feed.py
+++ b/backtrader/feed.py
@@ -86,8 +86,8 @@ class MetaAbstractDataBase(dataseries.OHLCDateTime.__class__):
             _obj.p.sessionend = _obj.p.sessionend.time()
 
         elif _obj.p.sessionend is None:
-            # remove 9 to avoid precision rounding errors
-            _obj.p.sessionend = datetime.time(23, 59, 59, 999990)
+            # remove 99 to avoid precision rounding errors
+            _obj.p.sessionend = datetime.time(23, 59, 59, 999900)
 
         if isinstance(_obj.p.fromdate, datetime.date):
             # push it to the end of the day, or else intraday


### PR DESCRIPTION
The precision of 'roundtrip' conversion of datetime [i.e: num2date(date2num(datetime)) ] is 10 microseconds.
therefore to prevent bug when performing double conversion of dates,
the resolution needs to be in order of magnitude lower - i.e. 100 ms.
Example: num2date(date2num(datetime(2021,3,12, 4,59,59,999990))) will be
rounded and return 2021-03-12_05:00:00.000000.