### PR TITLE
Do not load bar with the same timestamp as the latest bar;

### DIFF
--- a/backtrader/feeds/ibdata.py
+++ b/backtrader/feeds/ibdata.py
@@ -667,7 +667,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
         # The historical data has the same data but with 'date' instead of
         # 'time' for datetime
         dt = date2num(rtbar.time if not hist else rtbar.date)
-        if dt < self.lines.datetime[-1] and not self.p.latethrough:
+        if dt <= self.lines.datetime[-1] and not self.p.latethrough:
             return False  # cannot deliver earlier than already delivered
 
         self.lines.datetime[0] = dt
@@ -687,7 +687,7 @@ class IBData(with_metaclass(MetaIBData, DataBase)):
         # contains open/high/low/close/volume prices
         # Datetime transformation
         dt = date2num(rtvol.datetime)
-        if dt < self.lines.datetime[-1] and not self.p.latethrough:
+        if dt <= self.lines.datetime[-1] and not self.p.latethrough:
             return False  # cannot deliver earlier than already delivered
 
         self.lines.datetime[0] = dt


### PR DESCRIPTION
This can happen when joining data from file and live data
(backfilling). In this case, if the last bar of the file data
is of the same time as the bar in the live data - both of them will
be added.

Detailed example:
File data contains the daily bars of: [21/11/17, 21/11/18]. We're sending request for historical data between the dates: 21/11/17 - 21/11/23, and using backfilling from the file.
When loading the data - the 11/17 and 11/18 will be taken from the file, and since the data point of the 11/18 from the server does not fulfill the condition `dt < self.lines.datetime[-1]` it will be taken as well. 
End result: data contains 2 data points of the 11/18.