### PR TITLE
Resolves resampling issues due to timezone differences.

### DIFF
--- a/backtrader/resamplerfilter.py
+++ b/backtrader/resamplerfilter.py
@@ -46,6 +46,7 @@ class DTFaker(object):
 
     def __init__(self, data, forcedata=None):
         self.data = data
+        self._tz = data._tz
 
         # Aliases
         self.datetime = self
@@ -271,8 +272,8 @@ class _BaseResampler(with_metaclass(metabase.MetaParams, object)):
             return False
 
         # Get time objects for the comparisons - in utc-like format
-        tm = num2date(self.bar.datetime).time()
-        bartm = num2date(data.datetime[0]).time()
+        tm = num2date(self.bar.datetime, tz=data._tz).time()
+        bartm = num2date(data.datetime[0], tz=data._tz).time()
 
         point, _ = self._gettmpoint(tm)
         barpoint, _ = self._gettmpoint(bartm)


### PR DESCRIPTION
Datafeed sourced from IB API receives timezone info from contractdetails.
This tz info was not passed to num2date() method in lines 275 and 276.
This results in an offset in the point value returned by self._gettmpoint(tm).
This offset distorts the resampling and produces bars at irregular intervals.
Above modifications takes care of the same.

Note: Modified code was tested on `Minute 1` timeframe resampled to 20, 25 & 75 minutes using ibdata and data form local csv file.