### PR TITLE
Bugfix for NaN values in bbroker data.close[0]

### DIFF
--- a/backtrader/brokers/bbroker.py
+++ b/backtrader/brokers/bbroker.py
@@ -23,6 +23,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import collections
 import datetime
+import math
 
 import backtrader as bt
 from backtrader.comminfo import CommInfoBase
@@ -432,6 +433,9 @@ class BackBroker(bt.BrokerBase):
         for data in datas or self.positions:
             comminfo = self.getcommissioninfo(data)
             position = self.positions[data]
+            if math.isnan(data.close[0]):
+                # position inherently has no value.
+                continue
             # use valuesize:  returns raw value, rather than negative adj val
             if not self.p.shortcash:
                 dvalue = comminfo.getvalue(position, data.close[0])


### PR DESCRIPTION
,This fixes the backtest broker displaying NaN for the portfolio value returned by get_value/getvalue, even if there are no positions in the data feeds where the `data.close[0]` value is NaN.

Practical Example:
One wants to backtest multiple data feeds of different assets over various times. 
Backtrader is prefilled with all assets, but cannot invest in stocks that haven't IPOed yet, for example. Nevertheless, the data feed is already loaded.
This problem was also discussed [here](https://community.backtrader.com/topic/474/broker-getvalue-nan)

Fix:
- add python standard math dependency for isnan()
- check for NaN when computing the portfolio value.
- continue the value calculation loop if the closing price of the asset is NaN, no matter the position. If there is one, its worthless anyways.

Potential loopholes of fix:
- None is not yet checked for
- Infinity is not yet checked for.