### PR TITLE
Fix import of collections.Iterable

### DIFF
--- a/backtrader/lineiterator.py
+++ b/backtrader/lineiterator.py
@@ -22,6 +22,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import collections
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
 import operator
 import sys
 
@@ -226,7 +230,7 @@ class LineIterator(with_metaclass(MetaLineIterator, LineSeries)):
 
         if isinstance(owner, string_types):
             owner = [owner]
-        elif not isinstance(owner, collections.Iterable):
+        elif not isinstance(owner, collectionsAbc.Iterable):
             owner = [owner]
 
         if not own:
@@ -234,7 +238,7 @@ class LineIterator(with_metaclass(MetaLineIterator, LineSeries)):
 
         if isinstance(own, string_types):
             own = [own]
-        elif not isinstance(own, collections.Iterable):
+        elif not isinstance(own, collectionsAbc.Iterable):
             own = [own]
 
         for lineowner, lineown in zip(owner, own):


### PR DESCRIPTION
The `Iterable` class was moved from `collections` to `collections.abc` since Python 3.10.
With https://github.com/mementum/backtrader/pull/466, https://github.com/mementum/backtrader/pull/465 pull requests.