### PR TITLE
Update plot method for inline rendering

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -939,7 +939,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
     broker = property(getbroker, setbroker)
 
     def plot(self, plotter=None, numfigs=1, iplot=True, start=None, end=None,
-             width=16, height=9, dpi=300, tight=True, use=None,
+             width=None, height=None, dpi=None, tight=True, use=None,
              **kwargs):
         '''
         Plots the strategies inside cerebro
@@ -964,11 +964,11 @@ class Cerebro(with_metaclass(MetaParams, object)):
         ``datetime.date``, ``datetime.datetime`` instance indicating the end
         of the plot
 
-        ``width``: in inches of the saved figure
+        ``width``: in inches of the saved figure and inline display
 
-        ``height``: in inches of the saved figure
+        ``height``: in inches of the saved figure and inline display
 
-        ``dpi``: quality in dots per inches of the saved figure
+        ``dpi``: quality in dots per inches of the saved figure and inline display
 
         ``tight``: only save actual content and not the frame of the figure
         '''
@@ -977,6 +977,14 @@ class Cerebro(with_metaclass(MetaParams, object)):
 
         if not plotter:
             from . import plot
+            
+            if height is not None:
+                kwargs['height'] = height
+            if width is not None:
+                kwargs['width'] = width
+            if dpi is not None:
+                kwargs['dpi'] = dpi
+
             if self.p.oldsync:
                 plotter = plot.Plot_OldSync(**kwargs)
             else:
@@ -993,7 +1001,7 @@ class Cerebro(with_metaclass(MetaParams, object)):
             for si, strat in enumerate(stratlist):
                 rfig = plotter.plot(strat, figid=si * 100,
                                     numfigs=numfigs, iplot=iplot,
-                                    start=start, end=end, use=use)
+                                    start=start, end=end, use=use, **kwargs)
                 # pfillers=pfillers2)
 
                 figs.append(rfig)

--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -68,8 +68,8 @@ class PInfo(object):
 
         self.prop = mfontmgr.FontProperties(size=self.sch.subtxtsize)
 
-    def newfig(self, figid, numfig, mpyplot):
-        fig = mpyplot.figure(figid + numfig)
+    def newfig(self, figid, numfig, mpyplot, height, width, dpi):
+        fig = mpyplot.figure(figid + numfig, figsize = (height, width), dpi = dpi)
         self.figs.append(fig)
         self.daxis = collections.OrderedDict()
         self.vaxis = list()
@@ -133,6 +133,10 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
         import matplotlib.pyplot as mpyplot
         self.mpyplot = mpyplot
 
+        width = kwargs.get('width', mpyplot.rcParams["figure.figsize"][0])
+        height = kwargs.get('height', mpyplot.rcParams["figure.figsize"][1])
+        dpi = kwargs.get('dpi', mpyplot.rcParams["figure.dpi"])
+
         self.pinf = PInfo(self.p.scheme)
         self.sortdataindicators(strategy)
         self.calcrows(strategy)
@@ -167,7 +171,7 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
 
         for numfig in range(numfigs):
             # prepare a figure
-            fig = self.pinf.newfig(figid, numfig, self.mpyplot)
+            fig = self.pinf.newfig(figid, numfig, self.mpyplot, height, width, dpi)
             figs.append(fig)
 
             self.pinf.pstart, self.pinf.pend, self.pinf.psize = pranges[numfig]
@@ -252,7 +256,6 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
                 lastax = laxis[i]
                 if lastax not in self.pinf.vaxis:
                     break
-
                 i -= 1
 
             self.setlocators(lastax)  # place the locators/fmts


### PR DESCRIPTION
Refactor the plot method to enhance its flexibility by allowing easy updates to the height, width, and DPI parameters while _rendering it inline_ and saving the figure.

Usage example:
![image](https://github.com/mementum/backtrader/assets/7746531/563e45d7-9bd4-4a76-a4cc-25019af6dcf0)