### PR TITLE
Master

### DIFF
--- a/backtrader/analyzers/pyfolio.py
+++ b/backtrader/analyzers/pyfolio.py
@@ -127,7 +127,7 @@ class PyFolio(bt.Analyzer):
         #
         # Positions
         pss = self.rets['positions']
-        ps = [[k] + v[-2:] for k, v in iteritems(pss)]
+        ps = [[k] + v[:] for k, v in iteritems(pss)]
         cols = ps.pop(0)  # headers are in the first entry
         positions = DF.from_records(ps, index=cols[0], columns=cols)
         positions.index = pandas.to_datetime(positions.index)


### PR DESCRIPTION
in the analyser pyfolio.py only cash and the last equity will make their way into positions as the slice is v[-2:].

With the modification all the positions get mentioned and pyfolio-reloded will do full-tear-sheet.