### PR TITLE
rewind added to DataClone to fix bug of different length of data

### DIFF
--- a/backtrader/feed.py
+++ b/backtrader/feed.py
@@ -811,3 +811,7 @@ class DataClone(AbstractDataBase):
     def advance(self, size=1, datamaster=None, ticks=True):
         self._dlen += size
         super(DataClone, self).advance(size, datamaster, ticks=ticks)
+
+    def rewind(self, size=1):
+        self._dlen -= size
+        super(DataClone, self).rewind(size)


### PR DESCRIPTION
rewind is called in _runnext, it needs to be matched with advance

```
              # make sure only those at dmaster level end up delivering
                for i, dti in enumerate(dts):
                    if dti is not None:
                        di = datas[i]
                        rpi = False and di.replaying   # to check behavior
                        if dti > dt0:
                            if not rpi:  # must see all ticks ...
                                di.rewind()  # cannot deliver yet
                            # self._plotfillers[i].append(slen)
                        elif not di.replaying:
                            # Replay forces tick fill, else force here
                            di._tick_fill(force=True)

                        # self._plotfillers2[i].append(slen)  # mark as fill
```