### PR TITLE
Visualization of the backtrader codebase

### DIFF
--- a/.codeboarding/Analyzer.md
+++ b/.codeboarding/Analyzer.md
@@ -1,0 +1,253 @@
+```mermaid
+
+graph LR
+
+    Analyzer["Analyzer"]
+
+    MetaParams["MetaParams"]
+
+    WriterFile["WriterFile"]
+
+    AutoOrderedDict["AutoOrderedDict"]
+
+    TimeFrameAnalyzerBase["TimeFrameAnalyzerBase"]
+
+    DrawDown["DrawDown"]
+
+    SharpeRatio["SharpeRatio"]
+
+    TradeAnalyzer["TradeAnalyzer"]
+
+    TimeFrameAnalyzerBase -- "inherits from" --> Analyzer
+
+    DrawDown -- "inherits from" --> Analyzer
+
+    SharpeRatio -- "inherits from" --> Analyzer
+
+    TradeAnalyzer -- "inherits from" --> Analyzer
+
+    Analyzer -- "utilizes" --> WriterFile
+
+    MetaParams -- "manages parameters for" --> Analyzer
+
+    MetaParams -- "influences instantiation of" --> Analyzer
+
+    DrawDown -- "uses" --> AutoOrderedDict
+
+    TradeAnalyzer -- "uses" --> AutoOrderedDict
+
+    SharpeRatio -- "utilizes" --> TimeFrameAnalyzerBase
+
+    click Analyzer href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Analyzer.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Analyzer` subsystem in `backtrader` is designed to calculate and aggregate various performance metrics and statistics of a trading strategy during or after a backtest. Analyzers are attached to `Cerebro` or `Strategy` instances and process data as the simulation runs, providing valuable insights into strategy performance.
+
+
+
+### Analyzer
+
+This is the abstract base class (`backtrader.analyzer.Analyzer`) for all analyzers. It defines the essential interface and lifecycle methods (`start`, `stop`, `next`, `prenext`, `notify_trade`, `notify_order`, `notify_cashvalue`, `notify_fund`) that specialized analyzers must implement. It acts as the primary hook into the backtesting process, allowing data collection and processing. It also provides methods (`get_analysis`, `print`, `pprint`) for retrieving and presenting analysis results.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L88-L285" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer` (88:285)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L236-L239" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:start` (236:239)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L241-L244" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:stop` (241:244)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L217-L220" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:next` (217:220)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L222-L228" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:prenext` (222:228)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L213-L215" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:notify_trade` (213:215)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L209-L211" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:notify_order` (209:211)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L201-L203" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:notify_cashvalue` (201:203)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L205-L207" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:notify_fund` (205:207)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L254-L267" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:get_analysis` (254:267)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L269-L279" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:print` (269:279)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L281-L285" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.Analyzer:pprint` (281:285)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/writer.py#L42-L217" target="_blank" rel="noopener noreferrer">`backtrader.writer.WriterFile` (42:217)</a>
+
+
+
+
+
+### MetaParams
+
+A metaclass (`backtrader.metabase.MetaParams`) that underpins the parameter management system for `backtrader` components, including analyzers. It ensures that parameters defined within an analyzer class are correctly processed, inherited, and made accessible to instances. This provides a robust and consistent configuration mechanism for all analyzers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/metabase.py#L202-L292" target="_blank" rel="noopener noreferrer">`backtrader.metabase.MetaParams` (202:292)</a>
+
+
+
+
+
+### WriterFile
+
+This utility class (`backtrader.writer.WriterFile`) is responsible for flexible output of data to various streams, such as `sys.stdout` or a specified file. It supports different formatting options, including CSV and structured dictionary output, making it crucial for presenting the results generated by analyzers in a readable and customizable format.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/writer.py#L42-L217" target="_blank" rel="noopener noreferrer">`backtrader.writer.WriterFile` (42:217)</a>
+
+
+
+
+
+### AutoOrderedDict
+
+An extended version of `collections.OrderedDict` (`backtrader.utils.autodict.AutoOrderedDict`) that automatically creates nested dictionary structures upon accessing missing keys. This feature significantly simplifies the process of building complex, hierarchical data structures for storing analysis results within concrete analyzers. It also includes a `_close` method to prevent further key creation after the analysis is finalized.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/utils/autodict.py#L79-L144" target="_blank" rel="noopener noreferrer">`backtrader.utils.autodict.AutoOrderedDict` (79:144)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/utils/autodict.py#L82-L86" target="_blank" rel="noopener noreferrer">`backtrader.utils.autodict.AutoOrderedDict:_close` (82:86)</a>
+
+
+
+
+
+### TimeFrameAnalyzerBase
+
+An abstract base class (`backtrader.analyzer.TimeFrameAnalyzerBase`) that extends `Analyzer` to provide specialized functionality for analyses that are sensitive to specific timeframes (e.g., daily, weekly, monthly). It introduces logic to detect the beginning of new timeframe periods (`_dt_over`) and offers `on_dt_over` hooks for subclasses to perform calculations at these precise intervals.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L298-L445" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.TimeFrameAnalyzerBase` (298:445)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L345-L358" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.TimeFrameAnalyzerBase:_dt_over` (345:358)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L342-L343" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.TimeFrameAnalyzerBase:on_dt_over` (342:343)</a>
+
+
+
+
+
+### DrawDown
+
+A concrete implementation of an analyzer (`backtrader.analyzers.drawdown.DrawDown`) focused on calculating and tracking the maximum drawdown and other related statistics of a portfolio's equity curve. It overrides `create_analysis` to initialize an `AutoOrderedDict` for its results and implements `notify_fund` and `next` to perform its calculations based on portfolio value.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/drawdown.py#L30-L109" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.drawdown.DrawDown` (30:109)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/drawdown.py#L73-L84" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.drawdown.DrawDown:create_analysis` (73:84)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/drawdown.py#L89-L95" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.drawdown.DrawDown:notify_fund` (89:95)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/drawdown.py#L97-L109" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.drawdown.DrawDown:next` (97:109)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/utils/autodict.py#L79-L144" target="_blank" rel="noopener noreferrer">`backtrader.utils.autodict.AutoOrderedDict` (79:144)</a>
+
+
+
+
+
+### SharpeRatio
+
+A concrete analyzer (`backtrader.analyzers.sharpe.SharpeRatio`) that computes the Sharpe Ratio, a key measure of risk-adjusted return. It can be configured with various timeframes and risk-free rates. It often relies on other analyzers, such as `TimeReturn` (a `TimeFrameAnalyzerBase` subclass), to gather the necessary return data for its calculations, which are finalized in its `stop` method.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/sharpe.py#L32-L205" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.sharpe.SharpeRatio` (32:205)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/sharpe.py#L142-L205" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.sharpe.SharpeRatio:stop` (142:205)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L298-L445" target="_blank" rel="noopener noreferrer">`backtrader.analyzer.TimeFrameAnalyzerBase` (298:445)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/timereturn.py#L26-L141" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.timereturn.TimeReturn` (26:141)</a>
+
+
+
+
+
+### TradeAnalyzer
+
+A concrete analyzer (`backtrader.analyzers.tradeanalyzer.TradeAnalyzer`) that provides comprehensive statistics for individual trades executed during a backtest. This includes metrics like profit/loss, trade duration, winning/losing streaks, and average trade performance. It heavily leverages `AutoOrderedDict` to manage its complex, nested result structure and processes trade-related events via its `notify_trade` method.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/tradeanalyzer.py#L30-L207" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.tradeanalyzer.TradeAnalyzer` (30:207)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/tradeanalyzer.py#L75-L207" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.tradeanalyzer.TradeAnalyzer:notify_trade` (75:207)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/utils/autodict.py#L79-L144" target="_blank" rel="noopener noreferrer">`backtrader.utils.autodict.AutoOrderedDict` (79:144)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Broker.md
+++ b/.codeboarding/Broker.md
@@ -1,0 +1,199 @@
+```mermaid
+
+graph LR
+
+    BrokerBase["BrokerBase"]
+
+    BackBroker["BackBroker"]
+
+    IBBroker["IBBroker"]
+
+    OrderBase["OrderBase"]
+
+    CommInfoBase["CommInfoBase"]
+
+    Position["Position"]
+
+    Store["Store"]
+
+    IBStore["IBStore"]
+
+    BackBroker -- "inherits from" --> BrokerBase
+
+    IBBroker -- "inherits from" --> BrokerBase
+
+    BrokerBase -- "interacts with" --> CommInfoBase
+
+    BackBroker -- "manages" --> OrderBase
+
+    BackBroker -- "updates" --> Position
+
+    IBBroker -- "initializes with" --> IBStore
+
+    IBBroker -- "transmits orders via" --> IBStore
+
+    IBStore -- "updates" --> IBBroker
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Broker subsystem in backtrader is responsible for simulating or connecting to a real trading account, managing cash and portfolio value, and executing trading orders. It processes order requests from Strategies and notifies them of order status changes and trade executions.
+
+
+
+### BrokerBase
+
+The abstract base class that defines the fundamental interface and common functionalities for all broker implementations. It establishes how brokers manage cash, portfolio value, commissions, and the lifecycle of orders (submission, execution, cancellation, notification).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/broker.py#L48-L165" target="_blank" rel="noopener noreferrer">`backtrader.broker.BrokerBase` (48:165)</a>
+
+
+
+
+
+### BackBroker
+
+A concrete implementation of BrokerBase specifically designed for backtesting. It simulates order execution, cash management, and position tracking based on historical data, handling various order types and managing their states.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/brokers/bbroker.py#L35-L1232" target="_blank" rel="noopener noreferrer">`backtrader.brokers.bbroker.BackBroker` (35:1232)</a>
+
+
+
+
+
+### IBBroker
+
+A concrete implementation of BrokerBase for live trading with Interactive Brokers (IB). It translates backtrader orders into IB-specific requests, processes real-time updates from the IB TWS/Gateway, and manages account information, order status, and executions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/brokers/ibbroker.py#L239-L574" target="_blank" rel="noopener noreferrer">`backtrader.brokers.ibbroker.IBBroker` (239:574)</a>
+
+
+
+
+
+### OrderBase
+
+The base class for all order types (e.g., BuyOrder, SellOrder, Market, Limit, Stop). It defines the common attributes (status, size, price) and methods for an order, serving as a fundamental data structure processed by brokers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/order.py#L221-L524" target="_blank" rel="noopener noreferrer">`backtrader.order.OrderBase` (221:524)</a>
+
+
+
+
+
+### CommInfoBase
+
+A base class for defining commission schemes. Brokers use instances of this class to calculate commissions for trades, ensuring accurate financial reporting and realistic simulation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/comminfo.py#L29-L304" target="_blank" rel="noopener noreferrer">`backtrader.comminfo.CommInfoBase` (29:304)</a>
+
+
+
+
+
+### Position
+
+Represents an open position for a specific instrument. Brokers manage and update these positions as trades are executed, reflecting the current holdings of the trading account.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/position.py#L27-L205" target="_blank" rel="noopener noreferrer">`backtrader.position.Position` (27:205)</a>
+
+
+
+
+
+### Store
+
+The abstract base class for Store modules that act as the low-level communication layer with external trading platforms, handling API calls and data parsing, and often functioning as data feeds.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/store.py#L43-L93" target="_blank" rel="noopener noreferrer">`backtrader.store.Store` (43:93)</a>
+
+
+
+
+
+### IBStore
+
+A concrete implementation of Store for Interactive Brokers. It handles the direct communication with the IB API, managing data requests (historical and real-time) and receiving execution and account updates.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/stores/ibstore.py#L104-L1511" target="_blank" rel="noopener noreferrer">`backtrader.stores.ibstore.IBStore` (104:1511)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Cerebro.md
+++ b/.codeboarding/Cerebro.md
@@ -1,0 +1,283 @@
+```mermaid
+
+graph LR
+
+    Cerebro["Cerebro"]
+
+    Strategy["Strategy"]
+
+    Data_Feed["Data Feed"]
+
+    Broker["Broker"]
+
+    Observer["Observer"]
+
+    Analyzer["Analyzer"]
+
+    Sizer["Sizer"]
+
+    Indicator["Indicator"]
+
+    Writer["Writer"]
+
+    Timer["Timer"]
+
+    Cerebro -- "instantiates and manages" --> Strategy
+
+    Cerebro -- "manages collection of" --> Data_Feed
+
+    Cerebro -- "maintains instance of" --> Broker
+
+    Cerebro -- "adds and manages" --> Observer
+
+    Cerebro -- "adds and manages" --> Analyzer
+
+    Cerebro -- "adds and manages" --> Sizer
+
+    Cerebro -- "adds and manages" --> Indicator
+
+    Cerebro -- "adds and manages" --> Writer
+
+    Cerebro -- "instantiates and manages" --> Timer
+
+    Cerebro -- "injects Broker into" --> Strategy
+
+    Cerebro -- "injects Sizers into" --> Strategy
+
+    Cerebro -- "injects Indicators into" --> Strategy
+
+    Cerebro -- "injects Observers into" --> Strategy
+
+    Cerebro -- "injects Analyzers into" --> Strategy
+
+    Cerebro -- "drives time progression of" --> Data_Feed
+
+    Data_Feed -- "sends notifications to" --> Cerebro
+
+    Broker -- "sends notifications to" --> Cerebro
+
+    Cerebro -- "dispatches events to" --> Strategy
+
+    Cerebro -- "dispatches events to" --> Observer
+
+    Cerebro -- "dispatches events to" --> Writer
+
+    Strategy -- "uses" --> Sizer
+
+    Strategy -- "uses" --> Indicator
+
+    Strategy -- "uses" --> Data_Feed
+
+    Strategy -- "uses" --> Broker
+
+    click Cerebro href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Cerebro.md" "Details"
+
+    click Strategy href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Strategy.md" "Details"
+
+    click Data_Feed href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Data_Feed.md" "Details"
+
+    click Broker href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Broker.md" "Details"
+
+    click Analyzer href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Analyzer.md" "Details"
+
+    click Indicator href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Indicator.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Cerebro component in backtrader serves as the central orchestrator and execution engine for backtesting and live trading simulations. It manages the lifecycle and interactions of all other core components, driving the simulation process by advancing time and coordinating events.
+
+
+
+### Cerebro
+
+The core engine responsible for setting up, running, and managing the entire backtesting or live trading simulation. It acts as the central hub, connecting and coordinating data feeds, strategies, brokers, and other analytical or observational components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/cerebro.py#L59-L1715" target="_blank" rel="noopener noreferrer">`Cerebro` (59:1715)</a>
+
+
+
+
+
+### Strategy
+
+Encapsulates the trading logic, defining when to buy, sell, or hold assets based on market data and indicators. Cerebro instantiates and executes strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/strategy.py#L106-L1468" target="_blank" rel="noopener noreferrer">`Strategy` (106:1468)</a>
+
+
+
+
+
+### Data Feed
+
+Provides historical or live market data (e.g., OHLCV). Cerebro manages the data feeds, advancing them bar by bar or tick by tick, and making this data available to strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Data Feed` (1:1)
+
+
+
+
+
+### Broker
+
+Simulates or connects to a real trading broker, handling order execution, position management, and cash/portfolio tracking. Cerebro maintains an instance of the broker and interacts with it for trade operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/broker.py#L1-L1" target="_blank" rel="noopener noreferrer">`Broker` (1:1)</a>
+
+
+
+
+
+### Observer
+
+Monitors and collects information during the backtest or live trading, such as portfolio value, trade details, or specific metric changes. Cerebro adds and manages observers, which then receive notifications during the simulation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/observer.py#L45-L67" target="_blank" rel="noopener noreferrer">`Observer` (45:67)</a>
+
+
+
+
+
+### Analyzer
+
+Performs statistical analysis on the results of a backtest, providing metrics like returns, drawdown, or Sharpe ratio. Cerebro adds and manages analyzers, which process data collected during the run.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L88-L285" target="_blank" rel="noopener noreferrer">`Analyzer` (88:285)</a>
+
+
+
+
+
+### Sizer
+
+Determines the quantity (size) of an asset to trade when an order is placed. Cerebro can set a default sizer or assign specific sizers to individual strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/sizer.py#L28-L80" target="_blank" rel="noopener noreferrer">`Sizer` (28:80)</a>
+
+
+
+
+
+### Indicator
+
+Implements technical analysis calculations (e.g., Moving Averages, RSI). While indicators are often used within strategies, Cerebro can also add them globally to be available to all strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicator.py#L89-L135" target="_blank" rel="noopener noreferrer">`Indicator` (89:135)</a>
+
+
+
+
+
+### Writer
+
+Logs detailed information about the simulation to various outputs (e.g., CSV files, console). Cerebro manages the writers and feeds them data during the simulation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/writer.py#L1-L1" target="_blank" rel="noopener noreferrer">`Writer` (1:1)</a>
+
+
+
+
+
+### Timer
+
+Schedules time-based events within the simulation, allowing for actions to be triggered at specific times or intervals. Cerebro manages and notifies these timers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/timer.py#L41-L224" target="_blank" rel="noopener noreferrer">`Timer` (41:224)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Feed.md
+++ b/.codeboarding/Data_Feed.md
@@ -1,0 +1,335 @@
+```mermaid
+
+graph LR
+
+    backtrader_feed_AbstractDataBase["backtrader.feed.AbstractDataBase"]
+
+    backtrader_feeds_btcsv_CSV["backtrader.feeds.btcsv.CSV"]
+
+    backtrader_feeds_pandafeed_PandasData["backtrader.feeds.pandafeed.PandasData"]
+
+    backtrader_feeds_ibdata_IBData["backtrader.feeds.ibdata.IBData"]
+
+    backtrader_feeds_oanda_OandaData["backtrader.feeds.oanda.OandaData"]
+
+    backtrader_feeds_vcdata_VCData["backtrader.feeds.vcdata.VCData"]
+
+    backtrader_cerebro_Cerebro["backtrader.cerebro.Cerebro"]
+
+    backtrader_strategy_Strategy["backtrader.strategy.Strategy"]
+
+    backtrader_indicator_Indicator["backtrader.indicator.Indicator"]
+
+    backtrader_dataseries_OHLCDateTime["backtrader.dataseries.OHLCDateTime"]
+
+    backtrader_resamplerfilter["backtrader.resamplerfilter"]
+
+    backtrader_stores_IBStore["backtrader.stores.IBStore"]
+
+    backtrader_stores_OandaStore["backtrader.stores.OandaStore"]
+
+    backtrader_stores_VCStore["backtrader.stores.VCStore"]
+
+    backtrader_feed_AbstractDataBase -- "inherits from" --> backtrader_dataseries_OHLCDateTime
+
+    backtrader_feeds_btcsv_CSV -- "inherits from" --> backtrader_feed_AbstractDataBase
+
+    backtrader_feeds_pandafeed_PandasData -- "inherits from" --> backtrader_feed_AbstractDataBase
+
+    backtrader_feeds_ibdata_IBData -- "inherits from" --> backtrader_feed_AbstractDataBase
+
+    backtrader_feeds_oanda_OandaData -- "inherits from" --> backtrader_feed_AbstractDataBase
+
+    backtrader_feeds_vcdata_VCData -- "inherits from" --> backtrader_feed_AbstractDataBase
+
+    backtrader_cerebro_Cerebro -- "uses" --> backtrader_feed_AbstractDataBase
+
+    backtrader_feed_AbstractDataBase -- "populates" --> backtrader_dataseries_OHLCDateTime
+
+    backtrader_strategy_Strategy -- "consumes" --> backtrader_dataseries_OHLCDateTime
+
+    backtrader_indicator_Indicator -- "consumes" --> backtrader_dataseries_OHLCDateTime
+
+    backtrader_cerebro_Cerebro -- "manages" --> backtrader_strategy_Strategy
+
+    backtrader_cerebro_Cerebro -- "manages" --> backtrader_indicator_Indicator
+
+    backtrader_feed_AbstractDataBase -- "uses" --> backtrader_resamplerfilter
+
+    backtrader_feeds_ibdata_IBData -- "depends on" --> backtrader_stores_IBStore
+
+    backtrader_feeds_oanda_OandaData -- "depends on" --> backtrader_stores_OandaStore
+
+    backtrader_feeds_vcdata_VCData -- "depends on" --> backtrader_stores_VCStore
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Data Feed` subsystem in `backtrader` is crucial for providing time-series market data to the core `Cerebro` engine, which then disseminates it to `Strategies` and `Indicators`. This subsystem is designed to handle various data sources, manage data synchronization, and ensure data integrity through features like resampling.
+
+
+
+### backtrader.feed.AbstractDataBase
+
+This is the abstract base class for all data feeds in `backtrader`. It defines the fundamental interface and common functionalities for ingesting and managing time-series data. It handles parameters such as `dataname`, `compression`, `timeframe`, and date/time filtering (`fromdate`, `todate`, `sessionstart`, `sessionend`). It also manages internal data structures for filter operations and integrates with resampling/replaying capabilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feed.py#L121-L595" target="_blank" rel="noopener noreferrer">`backtrader.feed.AbstractDataBase` (121:595)</a>
+
+
+
+
+
+### backtrader.feeds.btcsv.CSV
+
+A concrete implementation of a data feed specifically designed to read market data from CSV files. This component is essential for backtesting, allowing users to easily load historical data from widely available CSV formats.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feeds/btcsv.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.feeds.btcsv.CSV` (1:1)</a>
+
+
+
+
+
+### backtrader.feeds.pandafeed.PandasData
+
+This data feed class enables the direct consumption of market data from Pandas DataFrames. It offers significant flexibility, allowing users to integrate custom data processing pipelines or pre-existing data in DataFrame format into `backtrader`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feeds/pandafeed.py#L106-L272" target="_blank" rel="noopener noreferrer">`backtrader.feeds.pandafeed.PandasData` (106:272)</a>
+
+
+
+
+
+### backtrader.feeds.ibdata.IBData
+
+This component provides live market data by integrating with Interactive Brokers (IB). It's crucial for real-time trading scenarios, fetching data directly from the IB platform.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feeds/ibdata.py#L44-L703" target="_blank" rel="noopener noreferrer">`backtrader.feeds.ibdata.IBData` (44:703)</a>
+
+
+
+
+
+### backtrader.feeds.oanda.OandaData
+
+A data feed component that connects to Oanda to provide live market data. Similar to `IBData`, it facilitates live trading operations by streaming real-time data from the Oanda platform.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feeds/oanda.py#L43-L448" target="_blank" rel="noopener noreferrer">`backtrader.feeds.oanda.OandaData` (43:448)</a>
+
+
+
+
+
+### backtrader.feeds.vcdata.VCData
+
+This data feed component is responsible for handling data streams from Visual Chart, a charting and trading platform. It allows integration with Visual Chart's data sources for analysis and trading.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feeds/vcdata.py#L46-L594" target="_blank" rel="noopener noreferrer">`backtrader.feeds.vcdata.VCData` (46:594)</a>
+
+
+
+
+
+### backtrader.cerebro.Cerebro
+
+The central orchestrator of the `backtrader` framework. `Cerebro` is responsible for adding and managing data feeds, running strategies, and coordinating the entire backtesting or live trading process. It acts as the primary consumer of data from the `Data Feed` components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/cerebro.py#L59-L1715" target="_blank" rel="noopener noreferrer">`backtrader.cerebro.Cerebro` (59:1715)</a>
+
+
+
+
+
+### backtrader.strategy.Strategy
+
+This is the core component where users implement their trading logic. Strategies consume market data provided by `Cerebro` (via `DataSeries`) to analyze market conditions, generate signals, and execute trades.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/strategy.py#L106-L1468" target="_blank" rel="noopener noreferrer">`backtrader.strategy.Strategy` (106:1468)</a>
+
+
+
+
+
+### backtrader.indicator.Indicator
+
+Components used for technical analysis. Indicators consume market data from `DataSeries` (provided by `Cerebro`) to calculate and generate technical signals or values (e.g., Moving Averages, RSI).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicator.py#L89-L135" target="_blank" rel="noopener noreferrer">`backtrader.indicator.Indicator` (89:135)</a>
+
+
+
+
+
+### backtrader.dataseries.OHLCDateTime
+
+Represents the actual time-series data lines (Open, High, Low, Close, Volume, DateTime) that are populated by `Data Feed` components. These `DataSeries` instances are then consumed by `Strategies` and `Indicators` for their calculations and decision-making.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/dataseries.py#L110-L111" target="_blank" rel="noopener noreferrer">`backtrader.dataseries.OHLCDateTime` (110:111)</a>
+
+
+
+
+
+### backtrader.resamplerfilter
+
+This component provides functionalities for resampling and replaying historical data within data feeds. It is crucial for handling different timeframes (e.g., converting tick data to 1-minute bars) and ensuring data consistency during backtesting or live trading.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/resamplerfilter.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.resamplerfilter` (1:1)</a>
+
+
+
+
+
+### backtrader.stores.IBStore
+
+Manages the underlying connection and data retrieval mechanisms for Interactive Brokers. It serves as a backend for the `IBData` feed, handling the complexities of API communication and data streaming.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `backtrader.stores.IBStore` (1:1)
+
+
+
+
+
+### backtrader.stores.OandaStore
+
+Manages the connection and data retrieval from Oanda, serving as a backend for the `OandaData` feed. It handles the specifics of Oanda's API for real-time data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `backtrader.stores.OandaStore` (1:1)
+
+
+
+
+
+### backtrader.stores.VCStore
+
+Manages the connection and data retrieval from Visual Chart, serving as a backend for the `VCData` feed. It handles the specific communication protocols for Visual Chart data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `backtrader.stores.VCStore` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Indicator.md
+++ b/.codeboarding/Indicator.md
@@ -1,0 +1,259 @@
+```mermaid
+
+graph LR
+
+    backtrader_indicator_Indicator["backtrader.indicator.Indicator"]
+
+    backtrader_lineseries_LineSeries["backtrader.lineseries.LineSeries"]
+
+    backtrader_functions["backtrader.functions"]
+
+    backtrader_indicators["backtrader.indicators"]
+
+    backtrader_indicators_basicops["backtrader.indicators.basicops"]
+
+    backtrader_indicators_mabase_MetaMovAvBase["backtrader.indicators.mabase.MetaMovAvBase"]
+
+    backtrader_indicators_aroon__AroonBase["backtrader.indicators.aroon._AroonBase"]
+
+    backtrader_indicators_stochastic__StochasticBase["backtrader.indicators.stochastic._StochasticBase"]
+
+    backtrader_indicators_crossover__CrossBase["backtrader.indicators.crossover._CrossBase"]
+
+    backtrader_indicators_atr_TrueRange["backtrader.indicators.atr.TrueRange"]
+
+    backtrader_indicator_Indicator -- "utilizes" --> backtrader_lineseries_LineSeries
+
+    backtrader_indicator_Indicator -- "inherits from" --> backtrader_metabase_MetaIndicator
+
+    backtrader_lineseries_LineSeries -- "used by" --> backtrader_indicator_Indicator
+
+    backtrader_lineseries_LineSeries -- "is base for" --> backtrader_dataseries_DataBase
+
+    backtrader_functions -- "provides utilities to" --> backtrader_indicators
+
+    backtrader_indicators -- "contains" --> backtrader_indicators_basicops
+
+    backtrader_indicators -- "depends on" --> backtrader_indicator_Indicator
+
+    backtrader_indicators_basicops -- "extends" --> backtrader_indicator_Indicator
+
+    backtrader_indicators_basicops -- "used by" --> backtrader_indicators
+
+    backtrader_indicators_mabase_MetaMovAvBase -- "manages" --> SMA
+
+    backtrader_indicators_mabase_MetaMovAvBase -- "manages" --> EMA
+
+    backtrader_indicators_mabase_MetaMovAvBase -- "extends" --> backtrader_indicator_Indicator___class__
+
+    backtrader_indicators_aroon__AroonBase -- "extends" --> backtrader_indicator_Indicator
+
+    backtrader_indicators_aroon__AroonBase -- "is base for" --> AroonUp
+
+    backtrader_indicators_aroon__AroonBase -- "is base for" --> AroonDown
+
+    backtrader_indicators_aroon__AroonBase -- "is base for" --> AroonOscillator
+
+    backtrader_indicators_stochastic__StochasticBase -- "extends" --> backtrader_indicator_Indicator
+
+    backtrader_indicators_stochastic__StochasticBase -- "is base for" --> StochasticFast
+
+    backtrader_indicators_stochastic__StochasticBase -- "is base for" --> Stochastic
+
+    backtrader_indicators_stochastic__StochasticBase -- "is base for" --> StochasticFull
+
+    backtrader_indicators_crossover__CrossBase -- "extends" --> backtrader_indicator_Indicator
+
+    backtrader_indicators_crossover__CrossBase -- "utilizes" --> backtrader_functions
+
+    backtrader_indicators_atr_TrueRange -- "extends" --> backtrader_indicator_Indicator
+
+    backtrader_indicators_atr_TrueRange -- "used by" --> backtrader_indicators_atr_AverageTrueRange
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Analysis of the `Indicator` subsystem in `backtrader`, focusing on its core components, their responsibilities, and interactions for implementing technical analysis calculations. The subsystem is built around the `Indicator` base class and `LineSeries` for data handling, supported by a `functions` module and organized into various specialized indicator modules and base classes for common patterns like moving averages, Aroon, Stochastic, and Crossover indicators. This structure promotes modularity, reusability, and consistency in developing technical analysis tools within `backtrader`.
+
+
+
+### backtrader.indicator.Indicator
+
+This is the foundational abstract base class for all technical indicators within `backtrader`. It provides the core mechanism for processing data lines, managing the indicator's state over time, and defining the `next` and `prenext` methods for iterative calculations. All concrete indicators inherit from this class, ensuring a consistent interface and lifecycle.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicator.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.indicator.Indicator:next` (1:1)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicator.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.indicator.Indicator:prenext` (1:1)</a>
+
+
+
+
+
+### backtrader.lineseries.LineSeries
+
+This component represents a generic series of data points over time. It is the primary data structure that indicators operate on (as input) and produce (as output). It provides methods for accessing historical data points and managing the series' length and synchronization, crucial for time-series analysis.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### backtrader.functions
+
+This module provides a collection of common mathematical and statistical functions (e.g., `Max`, `Min`, `Sum`, `Average`, `Div`) that are frequently used by various indicators for their calculations. These functions are designed to operate efficiently on `LineSeries` objects or their underlying data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/functions.py#L240-L241" target="_blank" rel="noopener noreferrer">`backtrader.functions.Max` (240:241)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/functions.py#L244-L245" target="_blank" rel="noopener noreferrer">`backtrader.functions.Min` (244:245)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/functions.py#L248-L249" target="_blank" rel="noopener noreferrer">`backtrader.functions.Sum` (248:249)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/functions.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.functions.Average` (1:1)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/functions.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.functions.Div` (1:1)</a>
+
+
+
+
+
+### backtrader.indicators
+
+This is the main package containing all concrete technical indicator implementations. Each file within this directory typically represents a specific indicator (e.g., SMA, MACD, RSI) or a base class for a family of indicators. These indicators inherit from `backtrader.indicator.Indicator` and utilize `LineSeries` and functions from `backtrader.functions` for their operations.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### backtrader.indicators.basicops
+
+This module contains fundamental operational indicators like `PeriodN`, `SumN`, `Average`, `ExponentialSmoothing`, and `WeightedAverage`. These are often used as low-level building blocks or helper indicators for constructing more complex technical indicators.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicators/basicops.py#L32-L43" target="_blank" rel="noopener noreferrer">`backtrader.indicators.basicops.PeriodN` (32:43)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicators/basicops.py#L160-L171" target="_blank" rel="noopener noreferrer">`backtrader.indicators.basicops.SumN` (160:171)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicators/basicops.py#L340-L363" target="_blank" rel="noopener noreferrer">`backtrader.indicators.basicops.Average` (340:363)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicators/basicops.py#L366-L411" target="_blank" rel="noopener noreferrer">`backtrader.indicators.basicops.ExponentialSmoothing` (366:411)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicators/basicops.py#L457-L493" target="_blank" rel="noopener noreferrer">`backtrader.indicators.basicops.WeightedAverage` (457:493)</a>
+
+
+
+
+
+### backtrader.indicators.mabase.MetaMovAvBase
+
+This metaclass is specifically involved in the registration and management of moving average indicators. Its `__new__` method intercepts class creation to register new moving average classes, providing a unified approach to their creation and configuration.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicators/mabase.py#L78-L85" target="_blank" rel="noopener noreferrer">`backtrader.indicators.mabase.MetaMovAvBase:__new__` (78:85)</a>
+
+
+
+
+
+### backtrader.indicators.aroon._AroonBase
+
+A specialized base class for the Aroon family of indicators (`AroonUp`, `AroonDown`, `AroonOscillator`). It encapsulates common logic, initialization, and calculation patterns shared by these related indicators, promoting code reuse and a consistent structure.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### backtrader.indicators.stochastic._StochasticBase
+
+Similar to `_AroonBase`, this is a specialized base class for the Stochastic family of indicators (`StochasticFast`, `Stochastic`, `StochasticFull`). It provides shared initialization and calculation logic, streamlining the implementation of these related indicators.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### backtrader.indicators.crossover._CrossBase
+
+A specialized base class for indicators that detect when one data line crosses another. It provides the core logic for identifying crossover events, often utilizing internal components like `NonZeroDifference` to determine the crossing condition.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/functions.py#L228-L229" target="_blank" rel="noopener noreferrer">`backtrader.functions.And` (228:229)</a>
+
+
+
+
+
+### backtrader.indicators.atr.TrueRange
+
+A specific indicator that calculates the True Range, which is a crucial component for other indicators like the Average True Range (ATR). It demonstrates the compositional nature of indicators, where simpler indicators can be used as building blocks for more complex ones.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Strategy.md
+++ b/.codeboarding/Strategy.md
@@ -1,0 +1,239 @@
+```mermaid
+
+graph LR
+
+    Strategy["Strategy"]
+
+    Cerebro["Cerebro"]
+
+    Broker["Broker"]
+
+    Data_Feeds["Data Feeds"]
+
+    Indicators["Indicators"]
+
+    Orders["Orders"]
+
+    Positions["Positions"]
+
+    Sizers["Sizers"]
+
+    CommInfoBase["CommInfoBase"]
+
+    Cerebro -- "manages" --> Strategy
+
+    Strategy -- "reports to" --> Cerebro
+
+    Strategy -- "places orders with" --> Broker
+
+    Broker -- "notifies" --> Strategy
+
+    Strategy -- "consumes" --> Data_Feeds
+
+    Data_Feeds -- "drive" --> Strategy
+
+    Strategy -- "utilizes" --> Indicators
+
+    Indicators -- "derive from" --> Data_Feeds
+
+    Strategy -- "creates" --> Orders
+
+    Strategy -- "receives updates on" --> Orders
+
+    Strategy -- "queries" --> Positions
+
+    Broker -- "manages" --> Positions
+
+    Strategy -- "uses" --> Sizers
+
+    Sizers -- "inform" --> Strategy
+
+    Broker -- "uses" --> CommInfoBase
+
+    click Strategy href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Strategy.md" "Details"
+
+    click Cerebro href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Cerebro.md" "Details"
+
+    click Broker href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Broker.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `backtrader` project is a Pythonic algorithmic trading library. The `Strategy` component is central to this system, as it encapsulates the user's trading logic and interacts with other core components to execute and manage trades.
+
+
+
+### Strategy
+
+The `Strategy` component (`backtrader.strategy.Strategy`) is the primary abstraction where users define their trading algorithms. It provides methods to interact with market data, place orders, manage positions, and incorporate technical indicators. It acts as the decision-making unit, reacting to market events and orchestrating trading operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/strategy.py#L106-L1468" target="_blank" rel="noopener noreferrer">`backtrader.strategy.Strategy` (106:1468)</a>
+
+
+
+
+
+### Cerebro
+
+`Cerebro` (`backtrader.cerebro.Cerebro`) is the core engine of `backtrader`. It orchestrates the entire backtesting or live trading process. It feeds market data to the `Strategy`, manages the lifecycle of strategies, brokers, data feeds, and other components, and handles the overall execution flow.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/cerebro.py#L59-L1715" target="_blank" rel="noopener noreferrer">`backtrader.cerebro.Cerebro` (59:1715)</a>
+
+
+
+
+
+### Broker
+
+The `Broker` component (`backtrader.broker.BrokerBase`) is responsible for simulating or executing trading orders. It manages cash, portfolio value, and positions, and notifies the `Strategy` about order status changes (e.g., filled, canceled, rejected).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/broker.py#L48-L165" target="_blank" rel="noopener noreferrer">`backtrader.broker.BrokerBase` (48:165)</a>
+
+
+
+
+
+### Data Feeds
+
+`Data Feeds` (represented by classes like `backtrader.feed.Feed` and its subclasses, though `Feed` itself is an abstract base) provide market data (e.g., OHLCV bars, tick data) to the `Strategy`. They are responsible for loading and delivering historical or live data in a structured format.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feed.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.feed.Feed` (1:1)</a>
+
+
+
+
+
+### Indicators
+
+`Indicators` (`backtrader.indicator.Indicator`) are technical analysis tools that process market data to generate signals or insights (e.g., Moving Averages, RSI, MACD). They are typically calculated based on `Data Feeds` or other indicators.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicator.py#L89-L135" target="_blank" rel="noopener noreferrer">`backtrader.indicator.Indicator` (89:135)</a>
+
+
+
+
+
+### Orders
+
+`Orders` (`backtrader.order.OrderBase`) represent trading instructions (buy/sell) with specific parameters (e.g., size, price, execution type). They are created by the `Strategy` and managed by the `Broker`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/order.py#L221-L524" target="_blank" rel="noopener noreferrer">`backtrader.order.OrderBase` (221:524)</a>
+
+
+
+
+
+### Positions
+
+`Positions` (`backtrader.position.Position`) track the current holdings of an asset (size and average entry price). They are managed by the `Broker` and provide the `Strategy` with information about its open trades.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/position.py#L27-L205" target="_blank" rel="noopener noreferrer">`backtrader.position.Position` (27:205)</a>
+
+
+
+
+
+### Sizers
+
+`Sizers` (`backtrader.sizer.Sizer`) determine the quantity of assets to trade for an order. They encapsulate the logic for calculating appropriate order sizes based on various factors (e.g., risk, capital, position).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/sizer.py#L28-L80" target="_blank" rel="noopener noreferrer">`backtrader.sizer.Sizer` (28:80)</a>
+
+
+
+
+
+### CommInfoBase
+
+`CommInfoBase` (`backtrader.comminfo.CommInfoBase`) defines the commission scheme and other financial parameters (e.g., margin, leverage, interest) associated with trading instruments. This information is used by the `Broker` to calculate costs and by the `Strategy` (implicitly through the Broker) for profit/loss calculations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/comminfo.py#L29-L304" target="_blank" rel="noopener noreferrer">`backtrader.comminfo.CommInfoBase` (29:304)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,199 @@
+```mermaid
+
+graph LR
+
+    Cerebro["Cerebro"]
+
+    Strategy["Strategy"]
+
+    Data_Feed["Data Feed"]
+
+    Broker["Broker"]
+
+    Indicator["Indicator"]
+
+    Analyzer["Analyzer"]
+
+    Cerebro -- "orchestrates" --> Strategy
+
+    Cerebro -- "processes" --> Data_Feed
+
+    Cerebro -- "interacts with" --> Broker
+
+    Cerebro -- "collects results from" --> Analyzer
+
+    Strategy -- "receives data from" --> Cerebro
+
+    Strategy -- "places orders via" --> Broker
+
+    Strategy -- "utilizes" --> Indicator
+
+    Data_Feed -- "supplies data to" --> Cerebro
+
+    Data_Feed -- "feeds" --> Indicator
+
+    Broker -- "executes orders for" --> Strategy
+
+    Broker -- "reports status to" --> Cerebro
+
+    Indicator -- "processes data from" --> Data_Feed
+
+    Indicator -- "provides signals to" --> Strategy
+
+    Analyzer -- "collects data from" --> Cerebro
+
+    Analyzer -- "outputs results to" --> Cerebro
+
+    click Cerebro href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Cerebro.md" "Details"
+
+    click Strategy href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Strategy.md" "Details"
+
+    click Data_Feed href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Data_Feed.md" "Details"
+
+    click Broker href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Broker.md" "Details"
+
+    click Indicator href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Indicator.md" "Details"
+
+    click Analyzer href "https://github.com/mementum/backtrader/blob/main/.codeboarding//Analyzer.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `backtrader` architecture is built around a core set of components that interact to simulate or execute trading strategies.
+
+
+
+### Cerebro
+
+The central orchestrator and execution engine of `backtrader`. It manages the lifecycle of all other components, including data feeds, strategies, brokers, analyzers, and observers, driving the simulation or live trading process by advancing time and coordinating interactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/cerebro.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.cerebro` (1:1)</a>
+
+
+
+
+
+### Strategy
+
+Encapsulates the user's trading logic. Users define their buy/sell rules, indicator usage, and order management within a `Strategy` subclass. It reacts to new market data and interacts with the `Broker` to place orders.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/strategy.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.strategy` (1:1)</a>
+
+
+
+
+
+### Data Feed
+
+Provides time-series market data (e.g., OHLCV bars, ticks) to `Cerebro` and subsequently to `Strategies` and `Indicators`. It handles loading data from various sources (CSV, Pandas DataFrames, live feeds) and manages data synchronization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feed.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.feed` (1:1)</a>
+
+- `backtrader.feeds.csvfeed` (1:1)
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/feeds/pandafeed.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.feeds.pandafeed` (1:1)</a>
+
+
+
+
+
+### Broker
+
+Simulates or connects to a real trading account. It manages cash, portfolio value, and the execution of trading orders. It processes order requests from `Strategies` and notifies them of order status changes and trade executions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/broker.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.broker` (1:1)</a>
+
+- `backtrader.brokers.backbroker` (1:1)
+
+
+
+
+
+### Indicator
+
+Implements technical analysis calculations (e.g., Moving Averages, MACD, RSI). Indicators operate on `Data Feeds` or other `Indicators`, producing new data series that `Strategies` can use.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicator.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.indicator` (1:1)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicators/sma.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.indicators.sma` (1:1)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/indicators/macd.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.indicators.macd` (1:1)</a>
+
+
+
+
+
+### Analyzer
+
+Calculates and aggregates various performance metrics and statistics of the trading strategy during or after a backtest. Analyzers are attached to `Cerebro` or `Strategy` and process data as the simulation runs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzer.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.analyzer` (1:1)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/drawdown.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.drawdown` (1:1)</a>
+
+- <a href="https://github.com/mementum/backtrader/blob/master/backtrader/analyzers/sharpe.py#L1-L1" target="_blank" rel="noopener noreferrer">`backtrader.analyzers.sharpe` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains diagrams which visualize the backtrader codebase. You can see how they render here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/backtrader/on_boarding.md

The aim of these diagrams is to help people get up-to-speed with the codebase. This said we don't want to introduce something which again will require you to maintain, so that is why we generated the diagrams with the help of static analysis and LLMs.

Backtrader has over 4.4K forks, which shows there's a strong community of developers engaging with the codebase—not just as users, but as contributors as well. From what we've seen, most of them are typically interested in modifying one or two components that are relevant to their specific needs.

With that in mind, we believe having a high-level diagram makes it much easier to navigate the system and quickly understand how a specific component fits into the broader architecture. To support this, we've also recently introduced a GitHub Action that keeps the diagrams automatically up-to-date with the latest changes.

We’d love to hear your thoughts on this approach. Also, how do you currently onboard new contributors to the codebase? If there's any way we can help streamline that process, we'd be happy to collaborate.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.

I would usually start by opening a discussion, but they are not enabled for this repository so I opened a PR instead!