### PR TITLE
Remove duplicate minperstatus dispatch in _oncepost_open

### DIFF
--- a/backtrader/strategy.py
+++ b/backtrader/strategy.py
@@ -281,13 +281,7 @@ class Strategy(with_metaclass(MetaStrategy, StrategyBase)):
         pass
 
     def _oncepost_open(self):
-        minperstatus = self._minperstatus
-        if minperstatus < 0:
-            self.next_open()
-        elif minperstatus == 0:
-            self.nextstart_open()  # only called for the 1st value
-        else:
-            self.prenext_open()
+        self._next_open()
 
     def _oncepost(self, dt):
         for indicator in self._lineiterators[LineIterator.IndType]:


### PR DESCRIPTION
_oncepost_open and _next_open share functional code. both read self._minperstatus and dispatched to prenext_open / nextstart_open / next_open. _oncepost_open now delegates to _next_open directly. Removes 4 lines of duplicated logic